### PR TITLE
Fix None cards in ubicar_jugador_en_zona

### DIFF
--- a/src/game/combate/mapa/mapa_global.py
+++ b/src/game/combate/mapa/mapa_global.py
@@ -36,7 +36,7 @@ class MapaGlobal:
 
         cartas_colocadas = 0
         for zona in zonas:
-            cartas_restantes = [c for c in jugador.cartas_banco if c.coordenada is None]
+            cartas_restantes = [c for c in jugador.cartas_banco if c is not None and c.coordenada is None]
             for carta in cartas_restantes:
                 coord = zona.obtener_coordenada_libre(self.tablero)
                 if coord:


### PR DESCRIPTION
## Summary
- handle `None` elements in `ubicar_jugador_en_zona`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'GestorInteracciones')*

------
https://chatgpt.com/codex/tasks/task_e_684e895fedd88326b5fb97bd4a2322e6