### PR TITLE
Add lazy imports and manual CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,33 +3,33 @@
 Auto-battler - Punto de entrada principal
 """
 
+import time
+
 from src.core.motor_juego import MotorJuego
+from src.core.jugador import Jugador
 from src.utils.helpers import log_evento
 
 
 def main():
-    """Función principal del juego"""
+    """Ejecuta una simulación automática con jugadores predeterminados."""
     print("=" * 50)
     print("🎮 AUTO-BATTLER - FASE PYTHON 🎮")
     print("=" * 50)
     print()
 
     try:
-        # Crear y configurar el motor
-        motor = MotorJuego()
+        jugadores = [Jugador(i + 1, f"Jugador {i+1}") for i in range(2)]
+        motor = MotorJuego(jugadores)
+        motor.iniciar()
+        while len(motor.jugadores_vivos) > 1 and motor.ronda <= 5:
+            motor.controlador_preparacion.finalizar_fase()
+            while motor.fase_actual != "preparacion" and len(motor.jugadores_vivos) > 1:
+                time.sleep(0.1)
 
-        # Ejecutar simulación con 4 jugadores por defecto
-        num_jugadores = 4
-        print(f"Iniciando simulación con {num_jugadores} jugadores...")
-        print()
-
-        motor.iniciar_simulacion(num_jugadores)
-
-        print()
-        print("=" * 50)
-        print("✅ Simulación completada exitosamente")
-        print("=" * 50)
-
+        if motor.jugadores_vivos:
+            print(f"🏆 Ganador: {motor.jugadores_vivos[0].nombre}")
+        else:
+            print("Empate.")
     except Exception as e:
         print(f"❌ Error durante la simulación: {e}")
         import traceback
@@ -60,13 +60,65 @@ def main_con_opciones():
             print("❌ Ingresa un número válido")
 
     print()
-    motor = MotorJuego()
-    motor.iniciar_simulacion(num_jugadores)
+    jugadores = [Jugador(i + 1, f"Jugador {i+1}") for i in range(num_jugadores)]
+    motor = MotorJuego(jugadores)
+    motor.iniciar()
+    while len(motor.jugadores_vivos) > 1 and motor.ronda <= 5:
+        motor.controlador_preparacion.finalizar_fase()
+        while motor.fase_actual != "preparacion" and len(motor.jugadores_vivos) > 1:
+            time.sleep(0.1)
+
+
+def juego_manual():
+    """Interfaz CLI simple para controlar a ambos jugadores."""
+    print("=" * 50)
+    print("🖥️  MODO MANUAL")
+    print("=" * 50)
+
+    nombres = []
+    for i in range(2):
+        n = input(f"Nombre para el jugador {i+1} (Enter para 'Jugador {i+1}'): ")
+        nombres.append(n.strip() or f"Jugador {i+1}")
+
+    jugadores = [Jugador(i + 1, nombre) for i, nombre in enumerate(nombres)]
+    motor = MotorJuego(jugadores)
+    motor.iniciar()
+
+    while len(motor.jugadores_vivos) > 1 and motor.ronda <= 5:
+        print(f"\n--- RONDA {motor.ronda} ---")
+        for jugador in motor.jugadores_vivos:
+            tienda = motor.get_tienda_para(jugador.id)
+            if not tienda:
+                continue
+            while True:
+                print(f"\n{jugador.nombre} - Oro {jugador.oro}")
+                for info in tienda.mostrar_cartas():
+                    print(info)
+                opcion = input("Indice para comprar, r para reroll, Enter para pasar: ")
+                if opcion.strip() == "":
+                    break
+                if opcion.lower() == "r":
+                    print(tienda.hacer_reroll())
+                    continue
+                try:
+                    idx = int(opcion)
+                except ValueError:
+                    print("Índice inválido")
+                    continue
+                print(tienda.comprar_carta(idx))
+        motor.controlador_preparacion.finalizar_fase()
+        while motor.fase_actual != "preparacion" and len(motor.jugadores_vivos) > 1:
+            time.sleep(0.1)
+
+    if motor.jugadores_vivos:
+        print(f"🏆 Ganador: {motor.jugadores_vivos[0].nombre}")
+    else:
+        print("Empate.")
 
 
 if __name__ == "__main__":
-    # Usar main() para ejecución automática o main_con_opciones() para interactiva
+    # Usar main() para ejecución automática o juego_manual() para interactivo
     main()
 
     # Descomentar la siguiente línea si quieres versión interactiva:
-    # main_con_opciones()
+    # juego_manual()

--- a/src/game/combate/__init__.py
+++ b/src/game/combate/__init__.py
@@ -1,0 +1,31 @@
+
+"""Expose key combat classes with lazy imports to avoid circular deps."""
+
+from __future__ import annotations
+
+import importlib
+
+__all__ = [
+    "GestorInteracciones",
+    "Interaccion",
+    "TipoInteraccion",
+    "MotorTiempoReal",
+    "MapaGlobal",
+]
+
+
+def __getattr__(name: str):
+    """Lazily load modules on attribute access."""
+    if name == "GestorInteracciones":
+        mod = importlib.import_module(".interacciones.gestor_interacciones", __name__)
+        return mod.GestorInteracciones
+    if name in {"Interaccion", "TipoInteraccion"}:
+        mod = importlib.import_module(".interacciones.interaccion_modelo", __name__)
+        return getattr(mod, name)
+    if name == "MotorTiempoReal":
+        mod = importlib.import_module(".motor.motor_tiempo_real", __name__)
+        return mod.MotorTiempoReal
+    if name == "MapaGlobal":
+        mod = importlib.import_module(".mapa.mapa_global", __name__)
+        return mod.MapaGlobal
+    raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Summary
- avoid circular imports by lazily loading combat components
- rework `main.py` with a simple CLI to control both players

## Testing
- `pytest -q` *(fails: test errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e8bb94f488326a601b5876f65d3ae