### PR TITLE
Add manual test mode for game phases

### DIFF
--- a/src/data/config/game_config.json
+++ b/src/data/config/game_config.json
@@ -5,5 +5,6 @@
   "cartas_por_tienda": 5,
   "copias_por_tier": {"1": 5, "2": 3, "3": 2},
   "max_cartas_por_tier": {"1": 0, "2": 0, "3": 0},
-  "cartas_activas": []
+  "cartas_activas": [],
+  "modo_testeo": false
 }

--- a/src/data/config/game_config.py
+++ b/src/data/config/game_config.py
@@ -28,3 +28,6 @@ class GameConfig:
 
         # Lista de IDs de cartas permitidas (vacío = todas)
         self.cartas_activas = data.get("cartas_activas", [])
+
+        # Modo testeo manual
+        self.modo_testeo = data.get("modo_testeo", False)

--- a/src/game/tienda/sistema_subastas.py
+++ b/src/game/tienda/sistema_subastas.py
@@ -8,11 +8,11 @@ from src.utils.helpers import log_evento
 
 
 class SistemaSubastas:
-    def __init__(self, jugadores: List, duracion_segundos: int = 15):
+    def __init__(self, jugadores: List, duracion_segundos: int = 15, modo_testeo: bool = False):
         self.jugadores = jugadores
-        self.cartas_subastadas: Dict[int, dict] = {}  # carta_id: {"carta": Carta, "mejor_oferta": int, "jugador": Jugador}
-        self.ofertas_por_jugador: Dict[int, List[int]] = {}  # jugador_id: [ids de cartas ofertadas]
-        self.tiempo_restante = duracion_segundos
+        self.cartas_subastadas: Dict[int, dict] = {}
+        self.ofertas_por_jugador: Dict[int, List[int]] = {}
+        self.tiempo_restante = None if modo_testeo else duracion_segundos
 
     # En src/game/tienda/sistema_subastas.py - método generar_subasta()
     def generar_subasta(self, cantidad: int = 3):

--- a/src/interfas/gui.py
+++ b/src/interfas/gui.py
@@ -55,6 +55,16 @@ class AutoBattlerGUI:
         self.crear_tab_tablero()
         self.crear_tab_combate()
 
+        # Controles de Testeo (ocultos por defecto)
+        self.frame_testeo = ttk.LabelFrame(self.root, text="Controles de Testeo")
+        self.lbl_proximo_paso = ttk.Label(self.frame_testeo, text="Próximo Paso: -")
+        self.lbl_proximo_paso.pack(side="left", padx=5)
+        ttk.Button(self.frame_testeo, text="Ejecutar Siguiente Paso", command=self.ejecutar_paso_testeo).pack(side="left", padx=5)
+        self.lbl_estado_actual = ttk.Label(self.frame_testeo, text="Estado: -")
+        self.lbl_estado_actual.pack(side="left", padx=5)
+        self.lbl_turno_activo = ttk.Label(self.frame_testeo, text="Turno: -")
+        self.lbl_turno_activo.pack(side="left", padx=5)
+
     def crear_tab_estado(self):
         # Tab de estado general del jugador
         frame = ttk.Frame(self.notebook)
@@ -188,6 +198,10 @@ class AutoBattlerGUI:
         self.motor = MotorJuego(self.jugadores)
         self.motor.iniciar()
 
+        if self.motor.modo_testeo:
+            self.frame_testeo.pack(fill="x", padx=10, pady=5)
+            self.actualizar_controles_testeo()
+
         # Configurar combo
         self.combo_jugador['values'] = [f"{j.nombre} (ID: {j.id})" for j in self.jugadores]
         self.combo_jugador.current(0)
@@ -234,6 +248,9 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
         self.actualizar_tienda()
         self.actualizar_subasta()
         self.actualizar_tablero()
+
+        if self.motor.modo_testeo:
+            self.actualizar_controles_testeo()
 
     def actualizar_banco(self):
         self.listbox_banco.delete(0, tk.END)
@@ -387,6 +404,23 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
 
     def usar_habilidad(self):
         messagebox.showinfo("Info", "Uso de habilidades en desarrollo")
+
+    # === CONTROLES DE TESTEO ===
+    def ejecutar_paso_testeo(self):
+        if self.motor:
+            self.motor.ejecutar_siguiente_paso()
+            self.actualizar_controles_testeo()
+
+    def actualizar_controles_testeo(self):
+        if not self.motor:
+            return
+        self.lbl_proximo_paso.config(text=f"Próximo Paso: {self.motor.describir_proximo_paso()}")
+        estado = f"{self.motor.fase_actual}"
+        self.lbl_estado_actual.config(text=f"Estado: {estado}")
+        turno = "-"
+        if hasattr(self.motor, 'controlador_enfrentamiento') and self.motor.controlador_enfrentamiento:
+            turno = self.motor.controlador_enfrentamiento.obtener_turno_activo()
+        self.lbl_turno_activo.config(text=f"Turno: {turno if turno else '-'}")
 
     def ejecutar(self):
         self.root.mainloop()


### PR DESCRIPTION
## Summary
- support manual test mode setting in config
- load `modo_testeo` in `GameConfig`
- extend `MotorJuego` to expose manual step execution
- refactor `ControladorFasePreparacion` for manual steps
- update combat controller for manual turn control
- allow `SistemaSubastas` to disable timer
- add testing controls in GUI

## Testing
- `pytest -q` *(fails: test_integration_fase_enfrentamiento_termina, test_creacion_tienda_y_subasta, test_ataque_directo_aplica_dano, test_interacciones_tablero_completo, test_interaccion_en_motor_tiempo_real)*

------
https://chatgpt.com/codex/tasks/task_e_684ea243a2ec8326b801732465645aa1