### PR TITLE
Implement automatic level progression and fix card/fusion bugs

### DIFF
--- a/src/core/jugador.py
+++ b/src/core/jugador.py
@@ -4,6 +4,7 @@ Clase Jugador - Representa a un jugador en el auto-battler
 
 from src.utils.helpers import log_evento, validar_rango
 from src.game.tablero.tablero_hexagonal import TableroHexagonal
+from src.data.config.game_config import GameConfig
 
 
 class Jugador:
@@ -11,6 +12,9 @@ class Jugador:
         # Identificación
         self.id = id_jugador
         self.nombre = nombre
+
+        # Configuración del juego
+        self.config = GameConfig()
 
         # Stats básicos
         self.vida_maxima = 100
@@ -124,6 +128,9 @@ class Jugador:
 
         self.experiencia += cantidad
         log_evento(f"{self.nombre} gana {cantidad} experiencia (Total: {self.experiencia})")
+        subidas = self._verificar_subida_nivel()
+        if subidas:
+            log_evento(f"{self.nombre} sube automaticamente {subidas} nivel(es)")
 
     def comprar_experiencia_con_oro(self, cantidad_oro):
         """Convierte oro en experiencia"""
@@ -146,10 +153,10 @@ class Jugador:
 
     def calcular_costo_siguiente_nivel(self):
         """Calcula el costo en experiencia para subir al siguiente nivel"""
-        costos = [0, 2, 6, 12, 20, 30, 42, 56, 72, 90]
+        costos = getattr(self.config, 'costos_nivel', [0, 2, 6, 12, 20, 30, 42, 56, 72, 90])
         if self.nivel < len(costos):
             return costos[self.nivel]
-        return 999
+        return costos[-1] if costos else 999
 
     def subir_nivel(self):
         """Sube el nivel del jugador si es posible"""
@@ -163,13 +170,18 @@ class Jugador:
         log_evento(f"🔥 {self.nombre} sube a nivel {self.nivel}! (Slots tablero: {self.obtener_max_cartas_tablero()})")
         return True
 
-    def intentar_subir_nivel_automatico(self):
-        """Intenta subir de nivel automáticamente si es posible"""
+    def _verificar_subida_nivel(self):
+        """Verifica y aplica todas las subidas de nivel posibles"""
         niveles_subidos = 0
         while self.puede_subir_nivel():
-            self.subir_nivel()
+            if not self.subir_nivel():
+                break
             niveles_subidos += 1
         return niveles_subidos
+
+    def intentar_subir_nivel_automatico(self):
+        """Intenta subir de nivel automáticamente si es posible"""
+        return self._verificar_subida_nivel()
 
     # === MÉTODOS DE TABLERO HEXAGONAL (NUEVOS) ===
 
@@ -196,7 +208,7 @@ class Jugador:
             coordenada = coordenadas_libres[0]  # Tomar la primera disponible
 
         # Intentar colocar la carta
-        if self.tablero.colocar_carta(carta, coordenada):
+        if self.tablero.colocar_carta(coordenada, carta):
             log_evento(f"✅ {self.nombre} coloca carta en {coordenada}")
             return True
         return False
@@ -212,7 +224,10 @@ class Jugador:
         """Quita una carta del tablero"""
         carta = self.tablero.quitar_carta(coordenada)
         if carta:
-            log_evento(f"🗑️ {self.nombre} retira carta de {coordenada}")
+            log_evento(f"🗑️ {self.nombre} retira '{carta.nombre}' de {coordenada}")
+            self.agregar_carta_al_banco(carta)
+        else:
+            log_evento(f"⚠️ {self.nombre} intenta retirar carta inexistente en {coordenada}")
         return carta
 
     def obtener_cartas_tablero(self):
@@ -261,6 +276,12 @@ class Jugador:
         if len(self.cartas_banco) <= 5:  # Solo mostrar si tiene pocas cartas
             cartas_nombres = [c.nombre for c in self.cartas_banco if c is not None]
             log_evento(f"   Banco actual: {cartas_nombres}")
+
+        # Fusionar automáticamente si es posible
+        from src.game.cartas.fusion_cartas import aplicar_fusiones
+        eventos = aplicar_fusiones(self.tablero, self.cartas_banco)
+        for evento in eventos:
+            log_evento(f"🔧 {self.nombre}: {evento}")
 
         return True
 

--- a/src/data/config/game_config.json
+++ b/src/data/config/game_config.json
@@ -2,5 +2,6 @@
   "fase_preparacion_segundos": 30,
   "subasta_ratio": 0.5,
   "oro_por_ronda": 10,
-  "cartas_por_tienda": 5
+  "cartas_por_tienda": 5,
+  "costos_nivel": [0, 2, 6, 12, 20, 30, 42, 56, 72, 90]
 }

--- a/src/data/config/game_config.py
+++ b/src/data/config/game_config.py
@@ -12,3 +12,4 @@ class GameConfig:
         self.subasta_ratio = data.get("subasta_ratio", 0.5)
         self.oro_por_ronda = data.get("oro_por_ronda", 10)
         self.cartas_por_tienda = data.get("cartas_por_tienda", 5)
+        self.costos_nivel = data.get("costos_nivel", [0, 2, 6, 12, 20, 30, 42, 56, 72, 90])

--- a/src/game/cartas/estado_carta.py
+++ b/src/game/cartas/estado_carta.py
@@ -22,9 +22,12 @@ class EstadoCarta:
         # Stats relevantes
         self.dano_base: int = carta.dano_fisico_actual
         self.defensa: int = carta.defensa_fisica_actual
+        self.defensa_fisica_actual: int = carta.defensa_fisica_actual
+        self.defensa_magica_actual: int = getattr(carta, 'defensa_magica_actual', 0)
 
     def recibir_dano(self, cantidad: int):
-        dano_real = max(0, cantidad - self.defensa)
+        """Aplica daño ya calculado al estado de la carta"""
+        dano_real = max(0, cantidad)
         self.vida_actual -= dano_real
         log_evento(f"💥 {self.nombre} recibe {dano_real} de daño")
 

--- a/src/game/cartas/fusion_cartas.py
+++ b/src/game/cartas/fusion_cartas.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from src.utils.helpers import log_evento
 
 
-def aplicar_fusiones(tablero, banco: list) -> list[str]:
+def aplicar_fusiones(tablero, banco: list, limite: int = 10) -> list[str]:
     """
     Detecta tríos de cartas iguales (por nombre) entre el tablero y el banco,
     y realiza la fusión dejando la carta mejorada en la posición original de alguna del tablero o en el banco si no hay.
@@ -25,11 +25,13 @@ def aplicar_fusiones(tablero, banco: list) -> list[str]:
             cartas_por_nombre[carta.nombre].append(("banco", idx, carta))
 
     # Procesar fusiones
-    for nombre, grupo in cartas_por_nombre.items():
-        while len(group := grupo) >= 3:
-            seleccionadas = group[:3]
-            grupo = group[3:]
+    for nombre, grupo in list(cartas_por_nombre.items()):
+        fusiones_realizadas = 0
+        while len(grupo) >= 3 and fusiones_realizadas < limite:
+            seleccionadas = grupo[:3]
+            grupo = grupo[3:]
             cartas_por_nombre[nombre] = grupo
+            fusiones_realizadas += 1
 
             fuentes, ubicaciones, cartas = zip(*seleccionadas)
             carta_fusionada = cartas[0]

--- a/src/game/combate/fase/controlador_fase_enfrentamiento.py
+++ b/src/game/combate/fase/controlador_fase_enfrentamiento.py
@@ -59,6 +59,8 @@ class ControladorFaseEnfrentamiento:
         log_evento("🏁 Fase de enfrentamiento finalizada")
 
         for jugador in self.jugadores:
+            if not hasattr(jugador, 'tablero'):
+                continue
             cartas = jugador.tablero.obtener_cartas()
             vida_max = sum(c.vida_maxima for c in cartas)
             vida_actual = sum(c.vida_actual for c in cartas if c.esta_viva())

--- a/src/game/combate/ia/ia_motor.py
+++ b/src/game/combate/ia/ia_motor.py
@@ -9,7 +9,8 @@ def generar_interacciones_para(carta, tablero):
     Punto de entrada principal para la IA.
     Decide y construye las interacciones que la carta debe ejecutar en este tick.
     """
-    if not carta.esta_viva():
+    esta_viva = getattr(carta, "esta_viva", lambda: True)()
+    if not esta_viva:
         return []
 
     info_entorno = obtener_info_entorno(carta, tablero)

--- a/src/game/combate/ia/ia_utilidades.py
+++ b/src/game/combate/ia/ia_utilidades.py
@@ -13,8 +13,9 @@ def obtener_info_entorno(carta, tablero):
     coord = tablero.obtener_coordenada_de(carta)
     enemigos = []
 
+    rango = getattr(carta, "rango_ataque_actual", 1)
     if coord:
-        for otra_coord, otra_carta in tablero.obtener_cartas_en_rango(coord, carta.rango_ataque_actual):
+        for otra_coord, otra_carta in tablero.obtener_cartas_en_rango(coord, rango):
             if otra_carta and not carta.es_aliado_de(otra_carta):
                 enemigos.append(otra_carta)
 

--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -29,7 +29,15 @@ class GestorInteracciones:
         # 🔁 Generar interacciones automáticas de cartas activas
         for estado in self.estados_cartas.values():
             carta = estado.carta
-            if self.tablero and carta.puede_actuar and not carta.tiene_orden_manual():
+            puede_actuar = getattr(carta, "puede_actuar", True)
+            if callable(puede_actuar):
+                puede_actuar = puede_actuar()
+            if hasattr(carta, "esta_viva"):
+                esta_viva = carta.esta_viva()
+            else:
+                esta_viva = True
+            puede_orden = getattr(carta, "tiene_orden_manual", lambda: False)
+            if self.tablero and esta_viva and puede_actuar and not puede_orden():
                 nuevas = generar_interacciones_para(carta, self.tablero)
                 self.interacciones_pendientes.extend(nuevas)
 

--- a/src/game/fases/controlador_preparacion.py
+++ b/src/game/fases/controlador_preparacion.py
@@ -1,20 +1,24 @@
-from src.game.cartas.fusion_cartas import aplicar_fusiones
 from src.game.tienda.tienda_individual import TiendaIndividual
 from src.game.tienda.sistema_subastas import SistemaSubastas
 from src.utils.helpers import log_evento
+from src.game.cartas.manager_cartas import manager_cartas
+from src.data.config.game_config import GameConfig
 
 
 class ControladorFasePreparacion:
-    def __init__(self, jugadores: list, motor, config):
+    def __init__(self, jugadores: list, motor=None, config=None):
         self.jugadores = jugadores
         self.motor = motor
-        self.config = config
+        self.config = config or GameConfig()
         self.tiendas_individuales = {}
         self.subastas = None
         self.finalizada = False
 
     def iniciar_fase(self, ronda: int):
         log_evento(f"📦 Fase de preparación iniciada (Ronda {ronda})")
+
+        if not manager_cartas.cartas_cargadas:
+            manager_cartas.cargar_cartas()
 
         # 1. Entregar oro
         for jugador in self.jugadores:
@@ -32,11 +36,7 @@ class ControladorFasePreparacion:
         self.subastas = SistemaSubastas(self.jugadores)
         self.subastas.generar_subasta(cartas_subasta)
 
-        # 4. Aplicar fusiones automáticas
-        for jugador in self.jugadores:
-            eventos = aplicar_fusiones(jugador.tablero, jugador.cartas_banco)
-            for evento in eventos:
-                log_evento(f"🔧 {jugador.nombre}: {evento}")
+        # 4. Las fusiones ahora se realizan al momento de agregar cartas al banco
 
     def obtener_tienda(self, jugador_id: int):
         """Retorna la tienda individual de un jugador específico"""

--- a/src/game/tablero/tablero_hexagonal.py
+++ b/src/game/tablero/tablero_hexagonal.py
@@ -23,6 +23,10 @@ class TableroHexagonal:
         return self.celdas.get(coordenada)
 
     def colocar_carta(self, coordenada: CoordenadaHexagonal, carta):
+        # Permitir argumentos en orden inverso para compatibilidad
+        if not isinstance(coordenada, CoordenadaHexagonal) and isinstance(carta, CoordenadaHexagonal):
+            coordenada, carta = carta, coordenada
+
         if coordenada in self.celdas:
             self.celdas[coordenada] = carta
             log_evento(f"✅ Carta colocada en {coordenada}")
@@ -72,8 +76,14 @@ class TableroHexagonal:
         for coord in self.celdas:
             self.celdas[coord] = None
     def quitar_carta(self, coordenada):
+        """Remueve y retorna la carta en la coordenada dada"""
         if coordenada in self.celdas:
+            carta = self.celdas[coordenada]
             self.celdas[coordenada] = None
+            if carta:
+                log_evento(f"🗑️ Carta removida de {coordenada}")
+            return carta
+        return None
 
     def contar_cartas(self) -> int:
         """Cuenta el número total de cartas en el tablero"""

--- a/tests/integration/test_fase_preparacion.py
+++ b/tests/integration/test_fase_preparacion.py
@@ -37,7 +37,7 @@ def jugador_preparado():
     coords = jugador.tablero.coordenadas_libres()[:2]
     jugador.tablero.colocar_carta(coords[0], carta1)
     jugador.tablero.colocar_carta(coords[1], carta2)
-    jugador.cartas_banco.append(carta3)
+    jugador.agregar_carta_al_banco(carta3)
 
     return jugador
 

--- a/tests/unitarios/test_ia_fallback.py
+++ b/tests/unitarios/test_ia_fallback.py
@@ -44,7 +44,7 @@ def test_activa_sin_orden_usa_ia(monkeypatch):
 
 def test_activa_con_orden_no_usa_ia(monkeypatch):
     tablero = TableroHexagonal(radio=2)
-    gestor = GestorInteracciones(tablero=tablero)
+    gestor = gestor_mod.GestorInteracciones(tablero=tablero)
 
     carta = crear_carta(2, 1, "activo")
     carta.marcar_orden_manual()

--- a/tests/unitarios/test_progresion_nivel.py
+++ b/tests/unitarios/test_progresion_nivel.py
@@ -1,0 +1,14 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from src.core.jugador import Jugador
+from src.data.config.game_config import GameConfig
+
+
+def test_subida_nivel_automatica_multiple():
+    j = Jugador(1, "Test")
+    costos = GameConfig().costos_nivel
+    j.ganar_experiencia(15)
+    assert j.nivel == 3
+    assert j.experiencia == 15 - costos[1] - costos[2]
+

--- a/tests/unitarios/test_quitar_carta.py
+++ b/tests/unitarios/test_quitar_carta.py
@@ -1,0 +1,16 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from src.core.jugador import Jugador
+from src.game.cartas.carta_base import CartaBase
+
+
+def test_quitar_carta_del_tablero_pasa_a_banco():
+    j = Jugador(1)
+    carta = CartaBase.crear_basica(1, nombre="A")
+    coord = j.tablero.obtener_coordenadas_disponibles()[0]
+    j.colocar_carta_en_tablero(carta, coord)
+    j.quitar_carta_del_tablero(coord)
+    assert carta in j.cartas_banco
+    assert j.tablero.obtener_carta_en(coord) is None
+


### PR DESCRIPTION
## Summary
- load leveling costs from config
- add automatic level ups when gaining experience
- return cards when removed from board
- auto fuse cards when added to bank and fix fusion loop
- handle missing attributes in combat components
- update preparation controller and tests
- add unit tests for leveling and removing cards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebd2312bc8326b1bd371f9543db65