### PR TITLE
Fix color assignment and improve combat UI

### DIFF
--- a/src/core/motor_juego.py
+++ b/src/core/motor_juego.py
@@ -1,4 +1,3 @@
-import random
 import time
 
 from src.core.jugador import Jugador
@@ -59,8 +58,10 @@ class MotorJuego:
 
         # 2. Asignar jugadores a zonas
         jugadores_por_color = {"rojo": [], "azul": []}
-        for jugador in self.jugadores_vivos:
-            color = random.choice(["rojo", "azul"])
+        colores = ["rojo", "azul"]
+        jugadores_ordenados = sorted(self.jugadores_vivos, key=lambda j: j.id)
+        for idx, jugador in enumerate(jugadores_ordenados):
+            color = colores[idx % len(colores)]
             jugador.color_fase_actual = color
             jugadores_por_color[color].append(jugador)
             mapa.ubicar_jugador_en_zona(jugador, color)

--- a/src/interfas/gui.py
+++ b/src/interfas/gui.py
@@ -218,10 +218,14 @@ class AutoBattlerGUI:
         self.interfaz_mapa = InterfazMapaGlobal(frame, self.mapa_global)
         self.interfaz_mapa.pack(fill="both", expand=True)
 
-        info_frame = ttk.LabelFrame(frame, text="Turno Actual")
+        info_frame = ttk.LabelFrame(frame, text="Estado Combate")
         info_frame.pack(fill="x")
-        self.lbl_turno_actual = ttk.Label(info_frame, text="Turno: -")
-        self.lbl_turno_actual.pack(side="left", padx=5)
+        self.lbl_turno_actual = ttk.Label(info_frame, text="TURNO ACTIVO: -", font=("Arial", 12, "bold"))
+        self.lbl_turno_actual.pack(side="top", padx=5, pady=2, anchor="w")
+        self.lbl_equipo_rojo = ttk.Label(info_frame, text="🔴 EQUIPO ROJO: -")
+        self.lbl_equipo_rojo.pack(side="top", padx=5, anchor="w")
+        self.lbl_equipo_azul = ttk.Label(info_frame, text="🔵 EQUIPO AZUL: -")
+        self.lbl_equipo_azul.pack(side="top", padx=5, anchor="w")
 
     # === MÉTODOS DE CONTROL ===
 
@@ -291,6 +295,16 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
         self.actualizar_tienda()
         self.actualizar_subasta()
         self.actualizar_tablero()
+        if hasattr(self, "interfaz_mapa"):
+            self.interfaz_mapa.actualizar()
+
+        if hasattr(self.motor, "controlador_enfrentamiento") and self.motor.controlador_enfrentamiento:
+            turno = self.motor.controlador_enfrentamiento.obtener_turno_activo()
+            self.lbl_turno_actual.config(text=f"TURNO ACTIVO: {turno.upper()}" if turno else "TURNO ACTIVO: -")
+            rojos = ", ".join(j.nombre for j in self.motor.controlador_enfrentamiento.turnos.jugadores_por_color.get("rojo", []))
+            azules = ", ".join(j.nombre for j in self.motor.controlador_enfrentamiento.turnos.jugadores_por_color.get("azul", []))
+            self.lbl_equipo_rojo.config(text=f"🔴 EQUIPO ROJO: {rojos or '-'}")
+            self.lbl_equipo_azul.config(text=f"🔵 EQUIPO AZUL: {azules or '-'}")
 
         if self.motor.modo_testeo:
             self.actualizar_controles_testeo()
@@ -603,6 +617,7 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
     def ejecutar_paso_testeo(self):
         if self.motor:
             self.motor.ejecutar_siguiente_paso()
+            self.actualizar_interfaz()
             self.actualizar_controles_testeo()
 
     def actualizar_controles_testeo(self):

--- a/src/interfas/interfaz_mapa_global.py
+++ b/src/interfas/interfaz_mapa_global.py
@@ -25,6 +25,10 @@ class InterfazMapaGlobal(ttk.Frame):
 
         self._dibujar_mapa()
 
+    def actualizar(self):
+        """Redibuja el mapa completo."""
+        self._dibujar_mapa()
+
     def _hex_points(self, x, y, size):
         import math
         points = []
@@ -54,6 +58,20 @@ class InterfazMapaGlobal(ttk.Frame):
                 color = "#bbbbff"
             points = self._hex_points(x + 200, y + 200, self.hex_size)
             self.canvas.create_polygon(points, fill=color, outline="black")
+        # Dibujar cartas en el tablero
+        for coord, carta in board.celdas.items():
+            if carta is None:
+                continue
+            x, y = self._coord_to_pixel(coord)
+            color = "red" if getattr(carta.duenio, "color_fase_actual", "rojo") == "rojo" else "blue"
+            self.canvas.create_text(
+                x + 200,
+                y + 200,
+                text=carta.nombre[:8],
+                fill=color,
+                font=("Arial", 8, "bold"),
+            )
+
         self.canvas.configure(scrollregion=self.canvas.bbox("all"))
         log_evento("Mapa global dibujado")
 


### PR DESCRIPTION
## Summary
- assign combat colors deterministically to keep teams balanced
- show cards and team colours in the global map
- display active turn and team assignments in combat tab

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f391e3ed08326b524c776099c5dd1