### PR TITLE
Fix global coordinate conversion and GUI updates

### DIFF
--- a/src/game/combate/mapa/mapa_global.py
+++ b/src/game/combate/mapa/mapa_global.py
@@ -40,7 +40,10 @@ class MapaGlobal:
     # En src/game/combate/mapa/mapa_global.py - método ubicar_jugador_en_zona()
     def ubicar_jugador_en_zona(self, jugador, color: str):
         zonas = self.zonas_rojas if color == "rojo" else self.zonas_azules
-        log_evento(f"🗺️ Ubicando {jugador.nombre} en zona {color.upper()}")
+        log_evento(
+            f"🗺️ Ubicando {jugador.nombre} en zona {color.upper()} ({len(zonas)} disponibles)",
+            "DEBUG",
+        )
 
         cartas_pendientes = [
             (coord, carta)
@@ -50,12 +53,26 @@ class MapaGlobal:
 
         cartas_colocadas = 0
         for zona in zonas:
+            log_evento(
+                f"🔍 ZONA {zona.color.upper()} centro: {zona.centro}",
+                "DEBUG",
+            )
             if not cartas_pendientes:
                 break
             nuevas_pendientes = []
             for coord_local, carta in cartas_pendientes:
                 coord_global = zona.convertir_a_global(coord_local)
-                if coord_global in zona.coordenadas and self.tablero.esta_vacia(coord_global):
+                dentro_tablero = self.tablero.esta_dentro_del_tablero(coord_global)
+                vacia = self.tablero.esta_vacia(coord_global)
+                log_evento(
+                    f"🔍 Coord local: {coord_local} → Global: {coord_global} | Dentro tablero? {dentro_tablero} | Vacía? {vacia}",
+                    "DEBUG",
+                )
+                if (
+                    dentro_tablero
+                    and coord_global in zona.coordenadas
+                    and vacia
+                ):
                     carta.coordenada = coord_global
                     self.tablero.colocar_carta(coord_global, carta)
                     log_evento(f"   📍 {carta.nombre} colocada en {coord_global}")

--- a/src/game/combate/mapa/zona_mapa.py
+++ b/src/game/combate/mapa/zona_mapa.py
@@ -1,5 +1,6 @@
 from typing import Set, Optional
 from src.game.tablero.coordenada import CoordenadaHexagonal
+from src.utils.helpers import log_evento
 
 
 class ZonaMapa:
@@ -24,5 +25,12 @@ class ZonaMapa:
 
     def convertir_a_global(self, coord_local: CoordenadaHexagonal) -> CoordenadaHexagonal:
         """Convierte una coordenada local (tablero individual) a coord. global en esta zona."""
-        return CoordenadaHexagonal(self.centro.q + coord_local.q, self.centro.r + coord_local.r)
+        coord_global = CoordenadaHexagonal(
+            self.centro.q + coord_local.q, self.centro.r + coord_local.r
+        )
+        log_evento(
+            f"ZONA {self.color.upper()} centro: {self.centro} | local {coord_local} → global {coord_global}",
+            "DEBUG",
+        )
+        return coord_global
 

--- a/src/interfas/gui.py
+++ b/src/interfas/gui.py
@@ -26,6 +26,7 @@ class AutoBattlerGUI:
         self.hover_hex = None
         self.modo_mover_carta = False
         self.coordenada_origen = None
+        self._ultimo_turno_mapa = None
 
         self.crear_interfaz_principal()
 
@@ -290,13 +291,21 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
             text=f"Exp: {self.jugador_actual.experiencia}"
         )
 
-        # Actualizar banco
+        # Actualizar banco y tablero siempre
         self.actualizar_banco()
-        self.actualizar_tienda()
-        self.actualizar_subasta()
+        if self.motor.fase_actual == "preparacion":
+            self.actualizar_tienda()
+            self.actualizar_subasta()
         self.actualizar_tablero()
+
         if hasattr(self, "interfaz_mapa"):
-            self.interfaz_mapa.actualizar()
+            if self.motor.fase_actual != "preparacion":
+                turno = None
+                if hasattr(self.motor, "controlador_enfrentamiento") and self.motor.controlador_enfrentamiento:
+                    turno = self.motor.controlador_enfrentamiento.obtener_turno_activo()
+                if turno != self._ultimo_turno_mapa:
+                    self.interfaz_mapa.actualizar()
+                    self._ultimo_turno_mapa = turno
 
         if hasattr(self.motor, "controlador_enfrentamiento") and self.motor.controlador_enfrentamiento:
             turno = self.motor.controlador_enfrentamiento.obtener_turno_activo()


### PR DESCRIPTION
## Summary
- log conversion from zone-local to global coordinates
- validate placement of cards inside map zones and board
- skip shop updates during combat and avoid redrawing map each tick

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f3db9ccf88326950c6b8928f5762e