### PR TITLE
Fix rendering of cards on global map

### DIFF
--- a/src/interfas/gui.py
+++ b/src/interfas/gui.py
@@ -26,7 +26,8 @@ class AutoBattlerGUI:
         self.hover_hex = None
         self.modo_mover_carta = False
         self.coordenada_origen = None
-        self._ultimo_turno_mapa = None
+        self._ultima_fase_mapa = None
+        self._ultimo_estado_mapa = None
 
         self.crear_interfaz_principal()
 
@@ -300,12 +301,23 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
 
         if hasattr(self, "interfaz_mapa"):
             if self.motor.fase_actual != "preparacion":
-                turno = None
-                if hasattr(self.motor, "controlador_enfrentamiento") and self.motor.controlador_enfrentamiento:
-                    turno = self.motor.controlador_enfrentamiento.obtener_turno_activo()
-                if turno != self._ultimo_turno_mapa:
+                estado_actual = tuple(
+                    (c.q, c.r, id(card) if card else None)
+                    for c, card in sorted(
+                        self.mapa_global.tablero.celdas.items(),
+                        key=lambda i: (i[0].q, i[0].r),
+                    )
+                )
+
+                if (
+                    estado_actual != self._ultimo_estado_mapa
+                    or self.motor.fase_actual != self._ultima_fase_mapa
+                ):
                     self.interfaz_mapa.actualizar()
-                    self._ultimo_turno_mapa = turno
+                    self._ultimo_estado_mapa = estado_actual
+                    self._ultima_fase_mapa = self.motor.fase_actual
+            else:
+                self._ultima_fase_mapa = self.motor.fase_actual
 
         if hasattr(self.motor, "controlador_enfrentamiento") and self.motor.controlador_enfrentamiento:
             turno = self.motor.controlador_enfrentamiento.obtener_turno_activo()

--- a/src/interfas/interfaz_mapa_global.py
+++ b/src/interfas/interfaz_mapa_global.py
@@ -62,13 +62,32 @@ class InterfazMapaGlobal(ttk.Frame):
         for coord, carta in board.celdas.items():
             if carta is None:
                 continue
+
+            # Posición base en el canvas
             x, y = self._coord_to_pixel(coord)
-            color = "red" if getattr(carta.duenio, "color_fase_actual", "rojo") == "rojo" else "blue"
-            self.canvas.create_text(
-                x + 200,
-                y + 200,
-                text=carta.nombre[:8],
+            cx, cy = x + 200, y + 200
+
+            # Color según dueño de la carta
+            jugador_color = getattr(carta.duenio, "color_fase_actual", "rojo")
+            color = "red" if jugador_color == "rojo" else "blue"
+
+            # Dibujar círculo representando la carta
+            radio = self.hex_size * 0.4
+            self.canvas.create_oval(
+                cx - radio,
+                cy - radio,
+                cx + radio,
+                cy + radio,
                 fill=color,
+                outline="black",
+            )
+
+            # Texto con el nombre (abreviado)
+            self.canvas.create_text(
+                cx,
+                cy,
+                text=carta.nombre[:8],
+                fill="white",
                 font=("Arial", 8, "bold"),
             )
 


### PR DESCRIPTION
## Summary
- show cards on the global map using colored circles
- track phase and board state to avoid unnecessary redraws

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f44be6a1483269e3482edcd5e7253