### PR TITLE
Fix map reference and add panel for combat

### DIFF
--- a/src/core/motor_juego.py
+++ b/src/core/motor_juego.py
@@ -24,6 +24,7 @@ class MotorJuego:
         self.modo_testeo = self.config.modo_testeo
 
         self.controlador_enfrentamiento = None
+        self.mapa_global = None
 
         # Controlador especializado para la fase de preparación
         self.controlador_preparacion = ControladorFasePreparacion(
@@ -55,6 +56,7 @@ class MotorJuego:
 
         # 1. Crear mapa global
         mapa = MapaGlobal()
+        self.mapa_global = mapa
 
         # 2. Asignar jugadores a zonas
         jugadores_por_color = {"rojo": [], "azul": []}


### PR DESCRIPTION
## Summary
- expose `mapa_global` in `MotorJuego`
- improve `InterfazMapaGlobal` with change detection, centering and highlighting
- connect GUI map to engine map and add card management panel
- allow manual movement of cards in test mode

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f46ea10c08326ae1da0e14f5c982e