### PR TITLE
Mejoras a subastas y comportamientos

### DIFF
--- a/src/core/motor_juego.py
+++ b/src/core/motor_juego.py
@@ -68,6 +68,16 @@ class MotorJuego:
             jugadores_por_color[color].append(jugador)
             mapa.ubicar_jugador_en_zona(jugador, color)
 
+        # Aplicar comportamientos asignados a las cartas
+        from src.game.cartas.carta_base import CartaBase
+        for carta in mapa.tablero.celdas.values():
+            if isinstance(carta, CartaBase) and getattr(carta, "comportamiento_asignado", None):
+                carta.modo_control = carta.comportamiento_asignado
+                log_evento(
+                    f"🎯 {carta.nombre} inicia como '{carta.modo_control}'",
+                    "DEBUG",
+                )
+
         # 3. Crear gestor de interacciones y motor
         gestor = GestorInteracciones(tablero=mapa.tablero)
         self.motor = MotorTiempoReal(fps_objetivo=20)

--- a/src/data/config/game_config.json
+++ b/src/data/config/game_config.json
@@ -3,8 +3,9 @@
   "subasta_ratio": 0.5,
   "oro_por_ronda": 10,
   "cartas_por_tienda": 5,
-  "copias_por_tier": {"1": 5, "2": 3, "3": 2},
+  "copias_por_tier": {"1": 8, "2": 5, "3": 3},
   "max_cartas_por_tier": {"1": 0, "2": 0, "3": 0},
+  "cartas_subasta_default": 5,
   "cartas_activas": [],
   "modo_testeo": false
 }

--- a/src/data/config/game_config.py
+++ b/src/data/config/game_config.py
@@ -12,11 +12,12 @@ class GameConfig:
         self.subasta_ratio = data.get("subasta_ratio", 0.5)
         self.oro_por_ronda = data.get("oro_por_ronda", 10)
         self.cartas_por_tienda = data.get("cartas_por_tienda", 5)
+        self.cartas_subasta_default = data.get("cartas_subasta_default", 5)
         # Cantidad de copias de cada carta por tier
         self.copias_por_tier = {
-            1: data.get("copias_por_tier", {}).get("1", 5),
-            2: data.get("copias_por_tier", {}).get("2", 3),
-            3: data.get("copias_por_tier", {}).get("3", 2),
+            1: data.get("copias_por_tier", {}).get("1", 8),
+            2: data.get("copias_por_tier", {}).get("2", 5),
+            3: data.get("copias_por_tier", {}).get("3", 3),
         }
 
         # Limitar cantidad de tipos de carta por tier (0 = sin límite)

--- a/src/game/cartas/carta_base.py
+++ b/src/game/cartas/carta_base.py
@@ -121,6 +121,7 @@ class CartaBase:
         self.modo_control = "pasivo"  # 'activo', 'pasivo' u 'orden_manual'
         self.orden_manual_pendiente = False
         self.orden_actual = None
+        self.comportamiento_asignado = None  # Preparación: comportamiento elegido
 
     @classmethod
     def crear_basica(cls, id, nombre="Carta", tier=1):
@@ -349,6 +350,21 @@ class CartaBase:
         self.orden_actual = None
         if self.modo_control == "orden_manual":
             self.modo_control = "pasivo"
+
+    def asignar_comportamiento(self, tipo: str) -> str:
+        """Asigna un comportamiento para el inicio del combate"""
+        comportamientos_validos = [
+            "agresivo",
+            "defensivo",
+            "explorador",
+            "guardian",
+            "seguidor",
+        ]
+        if tipo not in comportamientos_validos:
+            return "❌ Comportamiento inválido"
+        self.comportamiento_asignado = tipo
+        log_evento(f"🔧 {self.nombre} configurado como '{tipo}'")
+        return f"✅ Comportamiento '{tipo}' asignado"
     def obtener_habilidades_disponibles(self) -> List[Habilidad]:
         """Retorna lista de habilidades que pueden ser usadas"""
         return [hab for i, hab in enumerate(self.habilidades)

--- a/src/game/cartas/manager_cartas.py
+++ b/src/game/cartas/manager_cartas.py
@@ -32,10 +32,11 @@ class ManagerCartas:
 
         # Configuración
         self.config = config or GameConfig()
+        log_evento(f"ManagerCartas inicializado (id={id(self)})", "DEBUG")
         self.copias_por_tier = {
-            1: self.config.copias_por_tier.get(1, 5),
-            2: self.config.copias_por_tier.get(2, 3),
-            3: self.config.copias_por_tier.get(3, 2),
+            1: self.config.copias_por_tier.get(1, 8),
+            2: self.config.copias_por_tier.get(2, 5),
+            3: self.config.copias_por_tier.get(3, 3),
         }
         self.max_cartas_por_tier = self.config.max_cartas_por_tier
         self.cartas_activas = set(self.config.cartas_activas)
@@ -192,6 +193,11 @@ class ManagerCartas:
             log_evento("⚠️ Cartas no cargadas, retornando lista vacía")
             return []
 
+        log_evento(
+            f"[Pool {id(self)}] Solicitud de {cantidad} cartas (disponibles: {sum(self.pool_disponibles.values())})",
+            "DEBUG",
+        )
+
         probabilidades = self._obtener_probabilidades_tier(nivel_jugador)
         cartas_seleccionadas = []
 
@@ -267,6 +273,10 @@ class ManagerCartas:
     def devolver_carta_al_pool(self, carta: CartaBase):
         """Devuelve una carta al pool marcándola como disponible"""
         try:
+            log_evento(
+                f"[Pool {id(self)}] Devolviendo {carta.nombre} (ID: {carta.id})",
+                "DEBUG",
+            )
             # Obtener el ID base de la carta
             if hasattr(carta, 'carta_base_id'):
                 carta_base_id = carta.carta_base_id

--- a/src/game/fases/controlador_preparacion.py
+++ b/src/game/fases/controlador_preparacion.py
@@ -35,7 +35,7 @@ class ControladorFasePreparacion:
 
     def generar_subasta_publica(self):
         cartas_subasta = max(2, len(self.jugadores))
-        self.subastas = SistemaSubastas(self.jugadores, modo_testeo=self.modo_testeo)
+        self.subastas = SistemaSubastas(self.jugadores, modo_testeo=self.modo_testeo, config=self.config)
         self.subastas.generar_subasta(cartas_subasta)
 
     def pausar_para_ofertas(self):

--- a/src/game/tienda/sistema_subastas.py
+++ b/src/game/tienda/sistema_subastas.py
@@ -5,17 +5,21 @@ SistemaSubastas - Gestión de subastas públicas por ronda durante la fase de pr
 from typing import List, Dict, Optional
 from src.game.cartas.manager_cartas import manager_cartas
 from src.utils.helpers import log_evento
+from src.data.config.game_config import GameConfig
 
 
 class SistemaSubastas:
-    def __init__(self, jugadores: List, duracion_segundos: int = 15, modo_testeo: bool = False):
+    def __init__(self, jugadores: List, duracion_segundos: int = 15, modo_testeo: bool = False, config: GameConfig | None = None):
         self.jugadores = jugadores
         self.cartas_subastadas: Dict[int, dict] = {}
         self.ofertas_por_jugador: Dict[int, List[int]] = {}
         self.tiempo_restante = None if modo_testeo else duracion_segundos
+        self.config = config or GameConfig()
 
     # En src/game/tienda/sistema_subastas.py - método generar_subasta()
-    def generar_subasta(self, cantidad: int = 3):
+    def generar_subasta(self, cantidad: Optional[int] = None):
+        if cantidad is None:
+            cantidad = self.config.cartas_subasta_default
         self.cartas_subastadas.clear()
         log_evento(f"🏛️ Generando subasta con {cantidad} cartas:")
 

--- a/src/interfas/gui.py
+++ b/src/interfas/gui.py
@@ -195,6 +195,20 @@ class AutoBattlerGUI:
         ttk.Button(control_frame, text="Quitar del Tablero",
                    command=self.quitar_carta_tablero).pack(fill="x")
 
+        ttk.Label(control_frame, text="Comportamiento:").pack(pady=(5, 0))
+        self.combo_comportamiento = ttk.Combobox(
+            control_frame,
+            state="readonly",
+            values=["agresivo", "defensivo", "explorador", "guardian", "seguidor"],
+        )
+        self.combo_comportamiento.current(0)
+        self.combo_comportamiento.pack(fill="x")
+        ttk.Button(
+            control_frame,
+            text="Asignar Comportamiento",
+            command=self.asignar_comportamiento_preparacion,
+        ).pack(fill="x", pady=(2, 2))
+
         ttk.Separator(control_frame, orient="horizontal").pack(fill="x", pady=10)
         ttk.Label(control_frame, text="Cartas en Banco:").pack()
 
@@ -441,7 +455,8 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
         self.listbox_tablero.delete(0, tk.END)
         cartas_tablero = [par for par in self.jugador_actual.obtener_cartas_tablero() if par[1] is not None]
         for coord, carta in cartas_tablero:
-            self.listbox_tablero.insert(tk.END, f"{carta.nombre} en {coord}")
+            comp = carta.comportamiento_asignado or "-"
+            self.listbox_tablero.insert(tk.END, f"{carta.nombre} en {coord} ({comp})")
 
     def actualizar_panel_enfrentamiento(self):
         if not hasattr(self, "listbox_enfrentamiento"):
@@ -675,6 +690,22 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
         else:
             messagebox.showwarning("Error", "No se pudo quitar la carta")
         self.actualizar_interfaz()
+
+    def asignar_comportamiento_preparacion(self):
+        if not self.jugador_actual:
+            return
+        seleccion = self.listbox_tablero.curselection()
+        if not seleccion:
+            messagebox.showwarning("Advertencia", "Selecciona una carta del tablero")
+            return
+        cartas = [p for p in self.jugador_actual.obtener_cartas_tablero() if p[1] is not None]
+        if seleccion[0] >= len(cartas):
+            messagebox.showwarning("Error", "Selección inválida")
+            return
+        carta = cartas[seleccion[0]][1]
+        comportamiento = self.combo_comportamiento.get()
+        resultado = carta.asignar_comportamiento(comportamiento)
+        messagebox.showinfo("Comportamiento", resultado)
 
     def centrar_en_carta(self):
         if not self.motor or not self.motor.mapa_global:


### PR DESCRIPTION
## Summary
- agregar configuracion de `cartas_subasta_default`
- incrementar copias por tier y registrar id del pool
- permitir asignar comportamientos a cartas
- mostrar comportamiento y dropdown en la interfaz
- aplicar el comportamiento asignado al iniciar combate

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850d83291208326b9fcf0ef96365172