### PR TITLE
Implement basic fog of war and timed orders

### DIFF
--- a/src/core/motor_juego.py
+++ b/src/core/motor_juego.py
@@ -81,6 +81,7 @@ class MotorJuego:
         # 3. Crear gestor de interacciones y motor
         gestor = GestorInteracciones(tablero=mapa.tablero)
         self.motor = MotorTiempoReal(fps_objetivo=20)
+        gestor.motor = self.motor
         self.motor.agregar_componente(gestor)
 
         # 4. Inicializar turnos y controlador


### PR DESCRIPTION
## Summary
- enhance `InterfazMapaGlobal` with fog of war overlay and vision update method
- add timed pathfinding movement and continuous attack helpers
- allow `GestorInteracciones` to schedule movement/attack using the motor
- wire motor reference in `MotorJuego`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850dd69f15083269c0cb4050aecee7f