### PR TITLE
Update ignore rule for claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ __pycache__/
 *.py[cod]
 tests/
 
-claude/
+claude/**/
+!claude/
 deprec/


### PR DESCRIPTION
## Summary
- ignore only subdirectories within `claude` but allow files directly in that directory

## Testing
- `python -m py_compile main.py main_simulacion.py src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6850e90b54c883269d77ca7460e6ebe9