### PR TITLE
Improve GUI move orders and debugging

### DIFF
--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -38,10 +38,15 @@ class GestorInteracciones:
         )
         for estado in self.estados_cartas.values():
             carta = estado.carta
+            log_evento(f"👀 Revisando {carta.nombre}", "DEBUG")
             if self.tablero and carta.puede_actuar:
                 if carta.tiene_orden_manual():
                     log_evento(
                         f"🔎 {carta.nombre} tiene orden manual pendiente", "DEBUG"
+                    )
+                    log_evento(
+                        f"↪️ Ejecutando _procesar_orden_manual para {carta.nombre}",
+                        "DEBUG",
                     )
                     self._procesar_orden_manual(estado)
                 else:

--- a/src/interfas/gui.py
+++ b/src/interfas/gui.py
@@ -621,11 +621,16 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
             return
         coord = self.mapa_pixel_a_hex(event.x, event.y)
         tablero = self.motor.mapa_global.tablero
-        if not tablero.esta_dentro_del_tablero(coord) or not tablero.esta_vacia(coord):
+        if not tablero.esta_dentro_del_tablero(coord):
             messagebox.showwarning("Error", "Destino inválido")
             return
+
+        origen = tablero.obtener_coordenada_de(self.carta_seleccionada)
         self.carta_seleccionada.marcar_orden_manual("mover", coord)
-        log_evento(f"🎮 {self.jugador_actual.nombre} ordena mover a {self.carta_seleccionada.nombre}")
+        log_evento(
+            f"🎮 {self.jugador_actual.nombre} ordena mover {self.carta_seleccionada.nombre} "
+            f"desde {origen} hacia {coord}"
+        )
         self.ui_mode = "normal"
         self.interfaz_mapa.canvas.configure(cursor="")
         self.lbl_estado_orden.config(text="Estado: orden registrada")


### PR DESCRIPTION
## Summary
- allow selecting any map cell as movement destination
- include origin and destination in movement order logs
- add extra debug logs in GestorInteracciones

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f0ab8ea88326bdb6829f2c4387d1