### PR TITLE
Add debug logs for manual order processing

### DIFF
--- a/src/game/combate/ia/ia_utilidades.py
+++ b/src/game/combate/ia/ia_utilidades.py
@@ -80,6 +80,9 @@ def mover_carta_con_pathfinding(carta, destino, mapa, motor=None, on_step=None):
         return False
 
     log_evento(
+        f"🚶 INICIANDO pathfinding {carta.nombre}: {origen} → {destino}", "DEBUG"
+    )
+    log_evento(
         f"🧭 Buscando ruta para {carta.nombre}: {origen} → {destino}", "DEBUG"
     )
     ruta = _buscar_ruta(mapa, origen, destino)
@@ -87,6 +90,10 @@ def mover_carta_con_pathfinding(carta, destino, mapa, motor=None, on_step=None):
         log_evento("⚠️ Ruta no encontrada", "DEBUG")
         return False
 
+    log_evento(
+        f"🗺️ Ruta encontrada: {len(ruta)} pasos",
+        "DEBUG",
+    )
     log_evento(
         f"🚶 {carta.nombre} se mueve {origen} → {destino} ({len(ruta)} pasos)",
         "DEBUG",
@@ -111,7 +118,8 @@ def mover_carta_con_pathfinding(carta, destino, mapa, motor=None, on_step=None):
                 on_step()
 
         log_evento(
-            f"⏰ Programando paso a {paso} en {acumulado:.2f}s", "DEBUG"
+            f"⏰ Programando evento movimiento con delay {acumulado:.2f}s",
+            "DEBUG",
         )
         motor.programar_evento(_ejecutar, acumulado)
         acumulado += delay

--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -29,8 +29,14 @@ class GestorInteracciones:
 
     def procesar_tick(self, delta_time: float) -> bool:
         # 🔁 Generar interacciones u órdenes manuales
+        log_evento("🔄 GestorInteracciones.procesar_tick() ejecutándose", "DEBUG")
         if not self.tablero:
             return True
+
+        log_evento(
+            f"📊 Revisando {len([c for c in self.tablero.celdas.values() if c])} cartas en tablero",
+            "DEBUG",
+        )
 
         cartas_activas = {
             carta.id: carta
@@ -44,11 +50,14 @@ class GestorInteracciones:
         )
 
         for carta in cartas_activas.values():
-            log_evento(f"👀 Revisando {carta.nombre}", "DEBUG")
+            log_evento(
+                f"🔍 Revisando carta {carta.nombre} - tiene_orden_manual: {carta.tiene_orden_manual()}",
+                "DEBUG",
+            )
             if carta.puede_actuar:
                 if carta.tiene_orden_manual():
                     log_evento(
-                        f"🔎 {carta.nombre} tiene orden manual pendiente",
+                        f"📝 ORDEN DETECTADA en {carta.nombre}: {carta.orden_actual}",
                         "DEBUG",
                     )
                     log_evento(
@@ -91,7 +100,7 @@ class GestorInteracciones:
             return
 
         log_evento(
-            f"📝 Procesando orden '{orden.get('tipo')}' para {carta.nombre}",
+            f"⚙️ Procesando orden manual para {carta.nombre}: tipo={orden.get('tipo')}, progreso={orden.get('progreso')}",
             "DEBUG",
         )
 
@@ -129,12 +138,20 @@ class GestorInteracciones:
             if objetivo is None or not objetivo.esta_viva():
                 orden["progreso"] = "completada"
             else:
+                log_evento(
+                    f"🎯 Orden de ataque contra {objetivo.nombre} para {carta.nombre}",
+                    "DEBUG",
+                )
                 iniciar_ataque_continuo(carta, objetivo, self.tablero, self.motor)
                 orden["progreso"] = "completada"
 
         elif orden["tipo"] == "cambiar_comportamiento":
             nuevo = orden.get("datos_adicionales", {}).get("nuevo_comportamiento")
             if nuevo:
+                log_evento(
+                    f"🔄 Cambiando comportamiento de {carta.nombre} a '{nuevo}'",
+                    "DEBUG",
+                )
                 carta.modo_control = nuevo
             orden["progreso"] = "completada"
 


### PR DESCRIPTION
## Summary
- emit debug log when `GestorInteracciones.procesar_tick()` starts and show board size
- log each card iteration and detected manual order
- describe order state in `_procesar_orden_manual` and log actions for move, attack and behavior changes
- show detailed pathfinding workflow and event scheduling in `ia_utilidades.mover_carta_con_pathfinding`

## Testing
- `python -m py_compile src/game/combate/interacciones/gestor_interacciones.py src/game/combate/ia/ia_utilidades.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f7a2018083269497f10bf97b65ff