### PR TITLE
Refactor test mode timers, reduce noisy logs

### DIFF
--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -52,7 +52,7 @@ class GestorInteracciones:
         for carta in cartas_activas.values():
             log_evento(
                 f"🔍 Revisando carta {carta.nombre} - tiene_orden_manual: {carta.tiene_orden_manual()}",
-                "DEBUG",
+                "TRACE",
             )
             if carta.puede_actuar:
                 if carta.tiene_orden_manual():

--- a/src/game/combate/motor/motor_tiempo_real.py
+++ b/src/game/combate/motor/motor_tiempo_real.py
@@ -261,7 +261,7 @@ class MotorTiempoReal:
 
         log_evento(
             f"🌀 Tick motor con {len(self.componentes_activos)} componentes",
-            "DEBUG",
+            "TRACE",
         )
 
         # Procesar componentes activos
@@ -289,7 +289,7 @@ class MotorTiempoReal:
         for id_componente, componente in componentes:
             try:
                 # Procesar componente
-                log_evento(f"⚙️ Procesando componente {id_componente}", "DEBUG")
+                log_evento(f"⚙️ Procesando componente {id_componente}", "TRACE")
                 sigue_activo = componente.procesar_tick(delta_time)
 
                 if not sigue_activo:

--- a/src/game/tienda/sistema_subastas.py
+++ b/src/game/tienda/sistema_subastas.py
@@ -13,7 +13,7 @@ class SistemaSubastas:
         self.jugadores = jugadores
         self.cartas_subastadas: Dict[int, dict] = {}
         self.ofertas_por_jugador: Dict[int, List[int]] = {}
-        self.tiempo_restante = None if modo_testeo else duracion_segundos
+        self.tiempo_restante = 999999 if modo_testeo else duracion_segundos
         self.config = config or GameConfig()
 
     # En src/game/tienda/sistema_subastas.py - método generar_subasta()
@@ -73,3 +73,9 @@ class SistemaSubastas:
             f"{data['carta'].nombre} (ID: {cid}) - Mejor oferta: {data['mejor_oferta']}"
             for cid, data in self.cartas_subastadas.items()
         ]
+
+    def acelerar_temporizador(self, segundos: int = 2):
+        """Reduce el tiempo restante a los segundos indicados"""
+        if self.tiempo_restante is None:
+            return
+        self.tiempo_restante = segundos

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -41,6 +41,10 @@ def guardar_json(datos, ruta_archivo):
 
 def log_evento(mensaje, nivel="INFO"):
     """Registra un evento en consola y opcionalmente en archivo"""
+    if nivel == "TRACE":
+        # Logs de nivel TRACE se ignoran para evitar ruido en consola
+        return
+
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     # Formatear mensaje según nivel


### PR DESCRIPTION
## Summary
- add `TRACE` log level filtered in `log_evento`
- demote frequent debug logs in `MotorTiempoReal` and `GestorInteracciones`
- unify preparation controller to always run full logic and support large timers
- set long timers for subasta and combat turns in test mode
- add methods to accelerate timers when running in test mode
- simplify `MotorJuego` test mode flow to adjust timers instead of manual steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685108c0dcd883268c72ec8394ce89d4