### PR TITLE
Reduce console spam from ticks

### DIFF
--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -41,8 +41,8 @@ def guardar_json(datos, ruta_archivo):
 
 def log_evento(mensaje, nivel="INFO"):
     """Registra un evento en consola y opcionalmente en archivo"""
-    if nivel == "TRACE":
-        # Logs de nivel TRACE se ignoran para evitar ruido en consola
+    if nivel in ("TRACE", "DEBUG"):
+        # Logs muy verbosos se ignoran para evitar ruido en consola
         return
 
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Summary
- stop printing DEBUG messages in `log_evento`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68510b34dc408326bbb37604bca3274f