### PR TITLE
Fix map refresh and adjust movement speed

### DIFF
--- a/src/core/motor_juego.py
+++ b/src/core/motor_juego.py
@@ -15,9 +15,9 @@ from src.game.fases.controlador_preparacion import ControladorFasePreparacion
 
 
 class MotorJuego:
-    def __init__(self, jugadores: list[Jugador]):
+    def __init__(self, jugadores: list[Jugador] | None = None, on_step_callback=None):
         self.jugadores = jugadores
-        self.jugadores_vivos = list(jugadores)
+        self.jugadores_vivos = list(jugadores) if jugadores else []
         self.fase_actual = "preparacion"
         self.ronda = 1
         self.config = GameConfig()
@@ -25,6 +25,7 @@ class MotorJuego:
 
         self.controlador_enfrentamiento = None
         self.mapa_global = None
+        self.on_step_callback = on_step_callback
 
         # Controlador especializado para la fase de preparación
         self.controlador_preparacion = ControladorFasePreparacion(
@@ -73,7 +74,7 @@ class MotorJuego:
                 )
 
         # 3. Crear gestor de interacciones y motor
-        gestor = GestorInteracciones(tablero=mapa.tablero)
+        gestor = GestorInteracciones(tablero=mapa.tablero, on_step=self.on_step_callback)
         self.motor = MotorTiempoReal(fps_objetivo=20)
         gestor.motor = self.motor
 

--- a/src/data/cartas/personajes_historicos.json
+++ b/src/data/cartas/personajes_historicos.json
@@ -14,7 +14,7 @@
       "defensa_magica": 25,
       "rango_movimiento": 2,
       "rango_ataque": 3,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -51,7 +51,7 @@
       "defensa_magica": 15,
       "rango_movimiento": 3,
       "rango_ataque": 2,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -88,7 +88,7 @@
       "defensa_magica": 20,
       "rango_movimiento": 1,
       "rango_ataque": 3,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -127,7 +127,7 @@
       "defensa_magica": 15,
       "rango_movimiento": 2,
       "rango_ataque": 4,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -166,7 +166,7 @@
       "defensa_magica": 12,
       "rango_movimiento": 2,
       "rango_ataque": 1,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -204,7 +204,7 @@
       "defensa_magica": 35,
       "rango_movimiento": 1,
       "rango_ataque": 1,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -241,7 +241,7 @@
       "defensa_magica": 18,
       "rango_movimiento": 2,
       "rango_ataque": 2,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -279,7 +279,7 @@
       "defensa_magica": 15,
       "rango_movimiento": 1,
       "rango_ataque": 2,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -316,7 +316,7 @@
       "defensa_magica": 25,
       "rango_movimiento": 2,
       "rango_ataque": 1,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -355,7 +355,7 @@
       "defensa_magica": 20,
       "rango_movimiento": 1,
       "rango_ataque": 2,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -394,7 +394,7 @@
       "defensa_magica": 22,
       "rango_movimiento": 2,
       "rango_ataque": 3,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -432,7 +432,7 @@
       "defensa_magica": 20,
       "rango_movimiento": 2,
       "rango_ataque": 3,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -469,7 +469,7 @@
       "defensa_magica": 15,
       "rango_movimiento": 1,
       "rango_ataque": 2,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -507,7 +507,7 @@
       "defensa_magica": 12,
       "rango_movimiento": 2,
       "rango_ataque": 2,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -545,7 +545,7 @@
       "defensa_magica": 15,
       "rango_movimiento": 3,
       "rango_ataque": 1,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -582,7 +582,7 @@
       "defensa_magica": 18,
       "rango_movimiento": 3,
       "rango_ataque": 1,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -620,7 +620,7 @@
       "defensa_magica": 25,
       "rango_movimiento": 2,
       "rango_ataque": 3,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -658,7 +658,7 @@
       "defensa_magica": 12,
       "rango_movimiento": 1,
       "rango_ataque": 2,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -696,7 +696,7 @@
       "defensa_magica": 10,
       "rango_movimiento": 3,
       "rango_ataque": 1,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },
@@ -733,7 +733,7 @@
       "defensa_magica": 20,
       "rango_movimiento": 2,
       "rango_ataque": 2,
-      "velocidad_movimiento": 1.0,
+      "velocidad_movimiento": 0.5,
       "velocidad_ataque": 1.5,
       "rango_vision": 1
     },

--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -18,10 +18,11 @@ class GestorInteracciones:
     Se ejecuta como componente dentro del motor de tiempo real.
     """
 
-    def __init__(self, tablero=None, motor=None):
+    def __init__(self, tablero=None, motor=None, on_step=None):
         self.interacciones_pendientes: List[Interaccion] = []
         self.tablero = tablero
         self.motor = motor
+        self.on_step = on_step
 
     def registrar_interaccion(self, interaccion: Interaccion):
         log_evento(f"📨 Interacción registrada: {interaccion}")
@@ -124,6 +125,7 @@ class GestorInteracciones:
                     destino,
                     self.tablero,
                     motor=self.motor,
+                    on_step=self.on_step,
                 )
                 log_evento(
                     f"⏳ Movimiento programado ({'ok' if exito else 'fallo'})",

--- a/src/interfas/gui.py
+++ b/src/interfas/gui.py
@@ -240,6 +240,7 @@ class AutoBattlerGUI:
 
         self.mapa_global = None
         self.interfaz_mapa = InterfazMapaGlobal(frame, None)
+        self.interfaz_mapa.iniciar_actualizacion_automatica()
         self.interfaz_mapa.pack(side="left", fill="both", expand=True)
         self.interfaz_mapa.canvas.bind("<Button-1>", self.on_mapa_click)
 
@@ -298,7 +299,7 @@ class AutoBattlerGUI:
         self.jugadores = [j1, j2]
 
         # Inicializar motor
-        self.motor = MotorJuego(self.jugadores)
+        self.motor = MotorJuego(self.jugadores, on_step_callback=self.interfaz_mapa.forzar_actualizacion)
         self.motor.iniciar()
 
         if self.motor.modo_testeo:

--- a/src/interfas/interfaz_mapa_global.py
+++ b/src/interfas/interfaz_mapa_global.py
@@ -24,6 +24,8 @@ class InterfazMapaGlobal(ttk.Frame):
         super().__init__(master)
         self.mapa = mapa
         self._ultimo_estado = None
+        self._after_id = None
+        self._intervalo_ms = 500
         self.hex_size = hex_size
         self.celdas_visibles = set()  # coordenadas visibles para el jugador
 
@@ -196,4 +198,27 @@ class InterfazMapaGlobal(ttk.Frame):
             )
 
         self.canvas.configure(scrollregion=self.canvas.bbox("all"))
+
+    # === Actualización automática ===
+    def iniciar_actualizacion_automatica(self, intervalo_ms: int = 500):
+        """Inicia un loop que refresca el mapa periódicamente"""
+        self._intervalo_ms = intervalo_ms
+        if self._after_id:
+            self.after_cancel(self._after_id)
+        self._after_id = self.after(self._intervalo_ms, self._loop_actualizacion)
+
+    def detener_actualizacion_automatica(self):
+        """Detiene el refresco periódico"""
+        if self._after_id:
+            self.after_cancel(self._after_id)
+            self._after_id = None
+
+    def _loop_actualizacion(self):
+        self.forzar_actualizacion()
+        self._after_id = self.after(self._intervalo_ms, self._loop_actualizacion)
+
+    def forzar_actualizacion(self):
+        """Fuerza un redibujo del mapa"""
+        self._ultimo_estado = None
+        self.actualizar()
 


### PR DESCRIPTION
## Summary
- lower `velocidad_movimiento` of historical characters to 0.5
- add periodic update loop to `InterfazMapaGlobal`
- update GUI to start auto-refresh and notify map changes
- pass a callback from `MotorJuego` through `GestorInteracciones`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510e1e92a08326a2f28848af05c1fd