### PR TITLE
Implement coordinate toggle and dynamic zone generation

### DIFF
--- a/src/core/motor_juego.py
+++ b/src/core/motor_juego.py
@@ -55,7 +55,9 @@ class MotorJuego:
                 self.on_step_callback()
 
         # 1. Crear mapa global
-        mapa = MapaGlobal()
+        cant_jugadores = len(self.jugadores_vivos)
+        cantidad_parejas = (cant_jugadores + 1) // 2
+        mapa = MapaGlobal(cantidad_parejas=cantidad_parejas)
         self.mapa_global = mapa
 
         # 2. Asignar jugadores a zonas

--- a/src/interfas/gui.py
+++ b/src/interfas/gui.py
@@ -34,6 +34,7 @@ class AutoBattlerGUI:
         self._panel_coords = []
         self.carta_seleccionada = None
         self.ui_mode = "normal"  # normal, seleccionar_destino
+        self.var_mostrar_coordenadas = tk.BooleanVar(value=True)
 
         self.crear_interfaz_principal()
         self.root.after(500, self.refrescar_temporizadores)
@@ -240,7 +241,9 @@ class AutoBattlerGUI:
         from src.interfas.interfaz_mapa_global import InterfazMapaGlobal
 
         self.mapa_global = None
-        self.interfaz_mapa = InterfazMapaGlobal(frame, None, debug=True)
+        self.interfaz_mapa = InterfazMapaGlobal(
+            frame, None, debug=self.var_mostrar_coordenadas.get()
+        )
         self.interfaz_mapa.pack(side="left", fill="both", expand=True)
         self.interfaz_mapa.canvas.bind("<Button-1>", self.on_mapa_click)
         self.interfaz_mapa.canvas.bind("<Motion>", self.on_mapa_motion)
@@ -292,6 +295,13 @@ class AutoBattlerGUI:
         self.lbl_tiempo_turno.pack(side="top", padx=5, anchor="w")
         self.lbl_coord_mapa = ttk.Label(info_frame, text="Mapa: -")
         self.lbl_coord_mapa.pack(side="top", padx=5, anchor="w")
+        self.chk_mostrar_coords = ttk.Checkbutton(
+            info_frame,
+            text="Mostrar coordenadas",
+            variable=self.var_mostrar_coordenadas,
+            command=self.toggle_mostrar_coordenadas,
+        )
+        self.chk_mostrar_coords.pack(side="top", padx=5, anchor="w")
 
     # === MÉTODOS DE CONTROL ===
 
@@ -609,7 +619,6 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
         x = self.interfaz_mapa.canvas.canvasx(event.x)
         y = self.interfaz_mapa.canvas.canvasy(event.y)
         coord = self.interfaz_mapa.pixel_to_hex(x, y)
-        log_evento(f"Mapa click pixel=({x}, {y}) -> coord={coord}")
         if hasattr(self, "lbl_coord_mapa"):
             self.lbl_coord_mapa.config(text=f"Mapa: {coord}" if coord else "Mapa: -")
         if coord:
@@ -634,6 +643,11 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
         self.interfaz_mapa.canvas.configure(cursor="")
         self.lbl_estado_orden.config(text="Estado: orden registrada")
         self.actualizar_panel_ordenes()
+
+    def toggle_mostrar_coordenadas(self):
+        if self.interfaz_mapa:
+            self.interfaz_mapa.debug = self.var_mostrar_coordenadas.get()
+            self.interfaz_mapa.forzar_actualizacion()
 
     # === MÉTODOS DE ACCIÓN ===
 

--- a/src/interfas/interfaz_mapa_global.py
+++ b/src/interfas/interfaz_mapa_global.py
@@ -153,14 +153,10 @@ class InterfazMapaGlobal(ttk.Frame):
 
         # Verificar conversión inversa para depuración
         vx, vy = hex_to_pixel(coord, self.hex_size, self.offset)
-        log_evento(
-            f"pixel_to_hex: click ({x}, {y}) -> {coord} -> ({vx:.2f}, {vy:.2f})"
-        )
+        # Eliminado log detallado para evitar ruido al hacer clic
 
         if self.mapa and coord not in self.mapa.tablero.celdas:
-            log_evento(
-                f"pixel_to_hex: coordenada {coord} fuera del mapa", "DEBUG"
-            )
+            # No registrar en logs para no saturar la salida
             return None
 
         return coord


### PR DESCRIPTION
## Summary
- allow toggling of hex coordinates on the combat map
- remove click logging noise
- create combat maps with zone pairs based on player count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511be66b108326b32370d0691f62a3