### PR TITLE
Improve fog of war

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,11 @@ Los jugadores tienen un método para subir de nivel automáticamente utilizando 
 
 Estos bucles coordinados permiten que el juego avance por rondas ejecutando acciones en tiempo real y actualizando el estado de cada jugador.
 
+## Visibilidad y "fog of war"
+
+El mapa global implementa un sistema de celdas visibles por jugador.
+Cada carta tiene un `rango_vision` y las celdas en ese radio se añaden
+al conjunto de visibilidad. Al renderizar el tablero, las cartas
+enemigas solo se muestran cuando su coordenada pertenece a las celdas
+visibles del jugador actual, evitando revelar unidades ocultas.
+

--- a/src/interfas/interfaz_mapa_global.py
+++ b/src/interfas/interfaz_mapa_global.py
@@ -230,6 +230,8 @@ class InterfazMapaGlobal(ttk.Frame):
         for coord, carta in board.celdas.items():
             if carta is None:
                 continue
+            if self.celdas_visibles and coord not in self.celdas_visibles:
+                continue
 
             # Posición base en el canvas
             cx, cy = hex_to_pixel(coord, self.hex_size, self.offset)


### PR DESCRIPTION
## Summary
- skip rendering enemy cards that are outside the visible cells
- document the fog of war system in the readme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511e6a07c88326a39fcaa9d4da0c74