### PR TITLE
Fix attack flow respect attack speed

### DIFF
--- a/src/game/cartas/carta_base.py
+++ b/src/game/cartas/carta_base.py
@@ -87,6 +87,9 @@ class CartaBase:
         self.velocidad_ataque = stats_data.get('velocidad_ataque', 1.5)
         self.rango_vision = stats_data.get('rango_vision', 2)
 
+        # Control interno de tiempos para acciones
+        self.ultimo_ataque = 0.0
+
         # Stats actuales (pueden ser modificados por efectos)
         self.dano_fisico_actual = self.dano_fisico_base
         self.dano_magico_actual = self.dano_magico_base
@@ -173,6 +176,20 @@ class CartaBase:
         self.stats_combate['dano_recibido'] += dano_aplicado
 
         return dano_aplicado
+
+    # === MÉTODOS DE COMBATE ===
+
+    def puede_atacar(self, tiempo_actual: float | None = None) -> bool:
+        import time
+
+        if tiempo_actual is None:
+            tiempo_actual = time.time()
+        return (tiempo_actual - self.ultimo_ataque) >= self.velocidad_ataque
+
+    def registrar_ataque(self, tiempo: float | None = None):
+        import time
+
+        self.ultimo_ataque = tiempo if tiempo is not None else time.time()
 
     def curar(self, cantidad: int) -> int:
         """Cura a la carta sin exceder vida máxima"""

--- a/src/game/combate/ia/ia_motor.py
+++ b/src/game/combate/ia/ia_motor.py
@@ -7,6 +7,7 @@ from src.game.combate.ia.ia_utilidades import (
     mover_carta_con_pathfinding,
     atacar_si_en_rango,
 )
+import time
 
 
 def generar_interacciones_para(carta, tablero):
@@ -19,12 +20,21 @@ def generar_interacciones_para(carta, tablero):
 
     info_entorno = obtener_info_entorno(carta, tablero)
     decision = decidir_comportamiento(carta, info_entorno)
-    interacciones = construir_acciones(carta, decision, info_entorno)
 
-    # Acciones básicas: mover hacia objetivo y atacar si es posible
+    interacciones = []
+
     if decision["accion"] == "atacar" and decision["objetivos"]:
         objetivo = decision["objetivos"][0]
-        if not atacar_si_en_rango(carta, objetivo):
-            mover_carta_con_pathfinding(carta, objetivo.coordenada, tablero)
+
+        if carta.puede_atacar():
+            interacciones = construir_acciones(carta, decision, info_entorno)
+            if not atacar_si_en_rango(carta, objetivo):
+                mover_carta_con_pathfinding(carta, objetivo.coordenada, tablero)
+        else:
+            # No puede atacar aún, pero sí acercarse al objetivo
+            if not atacar_si_en_rango(carta, objetivo):
+                mover_carta_con_pathfinding(carta, objetivo.coordenada, tablero)
+    else:
+        interacciones = construir_acciones(carta, decision, info_entorno)
 
     return interacciones

--- a/src/game/combate/ia/ia_utilidades.py
+++ b/src/game/combate/ia/ia_utilidades.py
@@ -133,15 +133,27 @@ def atacar_si_en_rango(carta_atacante, carta_objetivo):
         return False
     if carta_atacante.coordenada.distancia(carta_objetivo.coordenada) > carta_atacante.rango_ataque_actual:
         return False
-    log_evento(f"⚔️ {carta_atacante.nombre} ataca a {carta_objetivo.nombre}")
     from src.game.combate.interacciones.interaccion_modelo import Interaccion, TipoInteraccion
+    from src.game.combate.calcular_dano.calculadora_dano import calcular_dano
+
     inter = Interaccion(
         fuente_id=carta_atacante.id,
         objetivo_id=carta_objetivo.id,
         tipo=TipoInteraccion.ATAQUE,
         metadata={"dano_base": carta_atacante.dano_fisico_actual},
     )
-    carta_objetivo.recibir_dano(carta_atacante.dano_fisico_actual)
+
+    dano = calcular_dano(carta_atacante, carta_objetivo, inter)
+    aplicado = carta_objetivo.recibir_dano(dano)
+    carta_atacante.registrar_ataque()
+
+    log_evento(
+        f"⚔️ {carta_atacante.nombre} golpea a {carta_objetivo.nombre} por {aplicado} daño (vida restante: {carta_objetivo.vida_actual})"
+    )
+
+    if not carta_objetivo.esta_viva():
+        carta_atacante.stats_combate["enemigos_eliminados"] += 1
+    carta_atacante.stats_combate["dano_infligido"] += aplicado
     return True
 
 

--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -25,7 +25,7 @@ class GestorInteracciones:
         self.on_step = on_step
 
     def registrar_interaccion(self, interaccion: Interaccion):
-        log_evento(f"📨 Interacción registrada: {interaccion}")
+        log_evento(f"📨 Interacción registrada: {interaccion}", "DEBUG")
         self.interacciones_pendientes.append(interaccion)
 
     def procesar_tick(self, delta_time: float) -> bool:
@@ -87,12 +87,23 @@ class GestorInteracciones:
         return True
 
     def _procesar_ataque(self, interaccion: Interaccion, fuente, objetivo):
-        # Registrar en log
-        log_evento(f"⚔️ {fuente.nombre} ataca a {objetivo.nombre}")
-
-        # Aplicar daño
         dano = calcular_dano(fuente, objetivo, interaccion)
-        objetivo.recibir_dano(dano)
+        aplicado = objetivo.recibir_dano(dano)
+        fuente.registrar_ataque()
+
+        log_evento(
+            f"⚔️ {fuente.nombre} golpea a {objetivo.nombre} por {aplicado} daño (vida restante: {objetivo.vida_actual})"
+        )
+
+        fuente.stats_combate["dano_infligido"] += aplicado
+        if not objetivo.esta_viva():
+            fuente.stats_combate["enemigos_eliminados"] += 1
+
+        if self.on_step:
+            try:
+                self.on_step()
+            except TypeError:
+                self.on_step()
 
     def _procesar_orden_manual(self, carta):
         """Ejecuta la orden manual asignada a la carta"""


### PR DESCRIPTION
## Summary
- honor `velocidad_ataque` by tracking last attack time on each card
- generate interactions only when cards can actually attack
- compute and log attack damage in a single place with remaining HP
- silence verbose logs for interaction registration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512031bbb48326909a9a61f54f6b4a