### PR TITLE
Improve combat behaviour and card removal

### DIFF
--- a/src/game/cartas/carta_base.py
+++ b/src/game/cartas/carta_base.py
@@ -90,6 +90,9 @@ class CartaBase:
         # Control interno de tiempos para acciones
         self.ultimo_ataque = 0.0
 
+        # Referencia al tablero actual (jugador o mapa global)
+        self.tablero = None
+
         # Stats actuales (pueden ser modificados por efectos)
         self.dano_fisico_actual = self.dano_fisico_base
         self.dano_magico_actual = self.dano_magico_base
@@ -306,7 +309,7 @@ class CartaBase:
             return []
 
         interacciones = []
-        enemigos_en_rango = tablero.obtener_cartas_en_rango(coord, self.rango)
+        enemigos_en_rango = tablero.obtener_cartas_en_rango(coord, self.rango_ataque_actual)
 
         for otra_coord, otra_carta in enemigos_en_rango:
             if otra_carta is self:

--- a/src/game/combate/ia/ia_comportamiento.py
+++ b/src/game/combate/ia/ia_comportamiento.py
@@ -9,6 +9,9 @@ def decidir_comportamiento(carta, info_entorno):
     vida_actual = carta.vida_actual
     vida_maxima = carta.vida_maxima
 
+    if carta.modo_control != "agresivo":
+        return {"accion": "esperar", "objetivos": []}
+
     if vida_actual < vida_maxima * 0.3:
         return {"accion": "huir", "objetivos": enemigos_cercanos}
 

--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -98,6 +98,22 @@ class GestorInteracciones:
         fuente.stats_combate["dano_infligido"] += aplicado
         if not objetivo.esta_viva():
             fuente.stats_combate["enemigos_eliminados"] += 1
+            if getattr(objetivo, "tablero", None) and getattr(objetivo, "coordenada", None):
+                objetivo.tablero.quitar_carta(objetivo.coordenada)
+                log_evento(f"💀 {objetivo.nombre} removida del mapa global")
+        else:
+            if (
+                getattr(objetivo, "tablero", None)
+                and getattr(objetivo, "coordenada", None)
+                and getattr(fuente, "coordenada", None)
+                and objetivo.coordenada.distancia(fuente.coordenada)
+                <= objetivo.rango_ataque_actual
+                and objetivo.puede_actuar
+                and objetivo.puede_atacar()
+            ):
+                from src.game.combate.ia.ia_utilidades import atacar_si_en_rango
+
+                atacar_si_en_rango(objetivo, fuente)
 
         if self.on_step:
             try:

--- a/src/game/tablero/tablero_hexagonal.py
+++ b/src/game/tablero/tablero_hexagonal.py
@@ -27,6 +27,8 @@ class TableroHexagonal:
             self.celdas[coordenada] = carta
             if hasattr(carta, "coordenada"):
                 carta.coordenada = coordenada
+            if hasattr(carta, "tablero"):
+                carta.tablero = self
             log_evento(f"✅ Carta colocada en {coordenada}")
         else:
             log_evento(f"❌ Coordenada {coordenada} no existe en el tablero")
@@ -84,6 +86,10 @@ class TableroHexagonal:
                     f"🔸 Carta '{getattr(carta, 'nombre', 'desconocida')}' retirada de {coordenada}",
                     "DEBUG",
                 )
+                if hasattr(carta, "coordenada"):
+                    carta.coordenada = None
+                if hasattr(carta, "tablero"):
+                    carta.tablero = None
         return carta
 
     def contar_cartas(self) -> int:

--- a/src/interfas/gui.py
+++ b/src/interfas/gui.py
@@ -822,12 +822,15 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
             messagebox.showwarning("Advertencia", "NO ES SU TURNO")
             return
         visibles = self.interfaz_mapa.calcular_celdas_visibles(self.jugador_actual)
+        rango = self.carta_seleccionada.rango_ataque_actual
         enemigos = []
         for coord, carta in self.motor.mapa_global.tablero.celdas.items():
             if (
                 carta is not None
                 and not self.carta_seleccionada.es_aliado_de(carta)
                 and coord in visibles
+                and self.carta_seleccionada.coordenada
+                and self.carta_seleccionada.coordenada.distancia(coord) <= rango
             ):
                 enemigos.append((coord, carta))
         if not enemigos:


### PR DESCRIPTION
## Summary
- track the board a card belongs to
- ensure interactions use attack range
- auto attack only for `agresivo` behaviour
- remove dead cards from global map and allow counterattacks
- filter attack target list by attack range

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685123110ea883269aae61395fad2bcb