### PR TITLE
Fix card death behavior

### DIFF
--- a/src/core/motor_juego.py
+++ b/src/core/motor_juego.py
@@ -91,8 +91,8 @@ class MotorJuego:
             f"✅ Componentes activos: {self.motor.obtener_componentes_activos()}"
         )
 
-        # Limpieza periódica de cartas muertas
-        self.motor.iniciar_limpieza_cartas_muertas(self.mapa_global)
+        # Limpieza periódica de cartas muertas deshabilitada para mantener las cartas en el mapa
+        # self.motor.iniciar_limpieza_cartas_muertas(self.mapa_global)
 
         # 4. Inicializar turnos y controlador
         secuencia = generar_secuencia_turnos()

--- a/src/game/cartas/carta_base.py
+++ b/src/game/cartas/carta_base.py
@@ -174,21 +174,23 @@ class CartaBase:
         if self.vida_actual <= 0:
             self.vida_actual = 0
             self.viva = False
+            self.puede_actuar = False
             try:
                 from src.utils.eventos import disparar
                 disparar("carta_muerta", carta=self)
             except Exception:
                 pass
-            if getattr(self, "tablero", None) and getattr(self, "coordenada", None):
-                try:
-                    self.tablero.quitar_carta(self.coordenada)
-                except Exception:
-                    pass
 
         # Actualizar estadísticas
         self.stats_combate['dano_recibido'] += dano_aplicado
 
         return dano_aplicado
+
+    def revivir(self):
+        """Restaura la carta a un estado activo al inicio de una nueva fase."""
+        self.vida_actual = self.vida_maxima
+        self.viva = True
+        self.puede_actuar = True
 
     # === MÉTODOS DE COMBATE ===
 

--- a/src/game/combate/fase/controlador_fase_enfrentamiento.py
+++ b/src/game/combate/fase/controlador_fase_enfrentamiento.py
@@ -96,6 +96,10 @@ class ControladorFaseEnfrentamiento:
             else:
                 log_evento(f"🛡️ {jugador.nombre} no recibe daño (vida intacta)")
 
+            # Revivir cartas para la siguiente fase
+            for carta in cartas:
+                carta.revivir()
+
 
         if self.al_terminar_fase:
             self.al_terminar_fase()

--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -98,9 +98,6 @@ class GestorInteracciones:
         fuente.stats_combate["dano_infligido"] += aplicado
         if not objetivo.esta_viva():
             fuente.stats_combate["enemigos_eliminados"] += 1
-            if self.tablero and getattr(objetivo, "coordenada", None):
-                self.tablero.quitar_carta(objetivo.coordenada)
-                log_evento(f"💀 {objetivo.nombre} removida del mapa global")
         else:
             if (
                 getattr(objetivo, "tablero", None)


### PR DESCRIPTION
## Summary
- avoid removing dead cards from boards
- disable card cleanup to keep them around
- revive cards after combat phase ends

## Testing
- `pytest -q`
- `ruff .` *(fails: 37 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68512fb83d448326838c994fe5012f2a