### PR TITLE
Fix dead card lingering on board

### DIFF
--- a/src/game/cartas/carta_base.py
+++ b/src/game/cartas/carta_base.py
@@ -175,6 +175,16 @@ class CartaBase:
             self.vida_actual = 0
             self.viva = False
             self.puede_actuar = False
+
+            # Remover del tablero si está colocada
+            if getattr(self, "tablero", None) and getattr(self, "coordenada", None):
+                try:
+                    self.tablero.quitar_carta(self.coordenada)
+                    from src.game.cartas.manager_cartas import manager_cartas
+                    manager_cartas.devolver_carta_al_pool(self)
+                except Exception:
+                    pass
+
             try:
                 from src.utils.eventos import disparar
                 disparar("carta_muerta", carta=self)

--- a/tests/test_carta_muerta.py
+++ b/tests/test_carta_muerta.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.game.tablero.tablero_hexagonal import TableroHexagonal
+from src.game.tablero.coordenada import CoordenadaHexagonal
+from src.game.cartas.carta_base import CartaBase
+
+
+def test_carta_muerta_se_remueve_del_tablero():
+    carta = CartaBase({'id': 1, 'nombre': 'Test', 'stats': {'vida': 5, 'dano_fisico': 1}})
+    tablero = TableroHexagonal(radio=1)
+    coord = CoordenadaHexagonal(0, 0)
+    tablero.colocar_carta(coord, carta)
+    assert tablero.obtener_carta_en(coord) is carta
+    carta.recibir_dano(10)
+    assert tablero.obtener_carta_en(coord) is None


### PR DESCRIPTION
## Summary
- remove dead cards from board in CartaBase.recibir_dano
- test that dead cards are cleared from the board automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852194fa3488326b60c1d1b5e115cb7