### PR TITLE
Auto place and starting card

### DIFF
--- a/src/core/jugador.py
+++ b/src/core/jugador.py
@@ -328,6 +328,28 @@ class Jugador:
         """Cuenta todas las cartas (tablero + banco)"""
         return self.contar_cartas_tablero() + self.contar_cartas_banco()
 
+    def autocompletar_tablero(self):
+        """Llena el tablero automáticamente con cartas del banco hasta el límite"""
+        max_cartas = self.obtener_max_cartas_tablero()
+        actuales = self.contar_cartas_tablero()
+        faltantes = max_cartas - actuales
+
+        if faltantes <= 0 or not self.cartas_banco:
+            return
+
+        log_evento(
+            f"🤖 Autocompletando tablero de {self.nombre}: {faltantes} espacios",
+            "DEBUG",
+        )
+
+        while faltantes > 0 and self.cartas_banco and self.puede_colocar_carta_en_tablero():
+            carta = self.cartas_banco.pop(0)
+            if not self.colocar_carta_en_tablero(carta):
+                # Si no se pudo colocar, devolver la carta y salir
+                self.cartas_banco.insert(0, carta)
+                break
+            faltantes -= 1
+
     # === MÉTODOS DE TOKENS Y COMBATE (sin cambios) ===
 
     def ganar_tokens_reroll(self, cantidad):

--- a/src/core/motor_juego.py
+++ b/src/core/motor_juego.py
@@ -1,4 +1,5 @@
 import time
+import random
 
 from src.core.jugador import Jugador
 from src.data.config.game_config import GameConfig
@@ -43,6 +44,8 @@ class MotorJuego:
         if not manager_cartas.cartas_cargadas:
             manager_cartas.cargar_cartas()
 
+        self._entregar_cartas_iniciales()
+
         self.controlador_preparacion.iniciar_fase(self.ronda)
 
     def _ejecutar_fase_combate(self):
@@ -59,6 +62,9 @@ class MotorJuego:
         cantidad_parejas = (cant_jugadores + 1) // 2
         mapa = MapaGlobal(cantidad_parejas=cantidad_parejas)
         self.mapa_global = mapa
+
+        # Autocompletar tableros antes de ubicar jugadores
+        self._autocompletar_tableros()
 
         # 2. Asignar jugadores a zonas
         jugadores_por_color = {"rojo": [], "azul": []}
@@ -193,4 +199,24 @@ class MotorJuego:
             self.controlador_preparacion.acelerar_temporizador()
         elif self.fase_actual == "combate" and self.controlador_enfrentamiento:
             self.controlador_enfrentamiento.acelerar_temporizador()
+
+    # === MÉTODOS AUXILIARES ===
+    def _entregar_cartas_iniciales(self):
+        """Da a todos los jugadores una carta inicial de un mismo tier (1 o 2)"""
+        if not self.jugadores_vivos:
+            return
+
+        tier = random.choice([1, 2])
+        log_evento(f"🎁 Entregando carta inicial de tier {tier} a todos los jugadores")
+        for jugador in self.jugadores_vivos:
+            carta = manager_cartas.obtener_carta_aleatoria_tier(tier)
+            if carta:
+                jugador.agregar_carta_al_banco(carta)
+            else:
+                log_evento("⚠️ No se pudo obtener carta inicial", "WARNING")
+
+    def _autocompletar_tableros(self):
+        """Autocompleta los tableros de los jugadores con cartas de su banco"""
+        for jugador in self.jugadores_vivos:
+            jugador.autocompletar_tablero()
 

--- a/src/game/cartas/manager_cartas.py
+++ b/src/game/cartas/manager_cartas.py
@@ -251,6 +251,16 @@ class ManagerCartas:
 
         return cartas_seleccionadas
 
+    def obtener_carta_aleatoria_tier(self, tier: int) -> Optional[CartaBase]:
+        """Obtiene una carta aleatoria de un tier específico"""
+        if not self.cartas_cargadas:
+            return None
+        ids = [cid for cid in self.cartas_por_tier.get(tier, []) if self.pool_disponibles.get(cid, 0) > 0]
+        if not ids:
+            return None
+        carta_id = random.choice(ids)
+        return self._tomar_instancia_del_pool(carta_id)
+
     def _tomar_instancia_del_pool(self, carta_id: int) -> Optional[CartaBase]:
         """Toma una instancia específica del pool y la marca como usada"""
         if carta_id not in self.pool_instancias or self.pool_disponibles.get(carta_id, 0) <= 0:


### PR DESCRIPTION
## Summary
- add bench auto-fill method in `Jugador`
- provide helper to draw a random card by tier
- distribute initial card to all players at game start
- automatically fill boards from bench when combat starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521af7b6b083268db76f30cd165a4f