### PR TITLE
Refactorizar gestión de eventos y validación en combate

### DIFF
--- a/src/game/cartas/carta_base.py
+++ b/src/game/cartas/carta_base.py
@@ -113,6 +113,8 @@ class CartaBase:
         self.viva = True
         self.puede_actuar = True
         self.efectos_activos = []
+        # Registro de eventos programados por el motor
+        self.eventos_activos: Dict[str, str] = {}
 
         # Posición (será asignada cuando se coloque en tablero)
         self.coordenada = None
@@ -392,6 +394,24 @@ class CartaBase:
         self.orden_actual = None
         if self.modo_control == "orden_manual":
             self.modo_control = "pasivo"
+
+    # --- Gestión de eventos activos ---
+    def registrar_evento_activo(self, tipo: str, id_evento: str):
+        """Asocia un ID de evento programado a la carta."""
+        self.eventos_activos[tipo] = id_evento
+
+    def cancelar_evento_activo(self, tipo: str, motor):
+        """Cancela un evento específico asociado a la carta."""
+        id_evento = self.eventos_activos.get(tipo)
+        if id_evento:
+            motor.cancelar_evento(id_evento)
+            self.eventos_activos.pop(tipo, None)
+
+    def cancelar_todos_eventos(self, motor):
+        """Cancela y limpia todos los eventos registrados para esta carta."""
+        for id_evento in list(self.eventos_activos.values()):
+            motor.cancelar_evento(id_evento)
+        self.eventos_activos.clear()
 
     def asignar_comportamiento(self, tipo: str) -> str:
         """Asigna un comportamiento para el inicio del combate"""

--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -132,6 +132,12 @@ class GestorInteracciones:
         if orden["progreso"] == "pendiente":
             orden["progreso"] = "ejecutando"
 
+        if self.motor:
+            try:
+                self.motor.cancelar_eventos_carta(carta)
+            except AttributeError:
+                pass
+
         if orden["tipo"] == "mover":
             destino = orden.get("objetivo")
             if destino is None:

--- a/src/game/combate/motor/motor_tiempo_real.py
+++ b/src/game/combate/motor/motor_tiempo_real.py
@@ -222,6 +222,14 @@ class MotorTiempoReal:
 
         return False
 
+    def cancelar_eventos_carta(self, carta) -> None:
+        """Cancela todos los eventos registrados por una carta."""
+        ids = getattr(carta, "eventos_activos", {}).values()
+        for id_evento in list(ids):
+            self.cancelar_evento(id_evento)
+        if hasattr(carta, "eventos_activos"):
+            carta.eventos_activos.clear()
+
     def _loop_principal(self):
         """Loop principal del motor (ejecutado en hilo separado)"""
         log_evento(f"🔄 Loop principal iniciado (Objetivo: {self.fps_objetivo} FPS)")


### PR DESCRIPTION
## Summary
- add tracking for active events per card
- allow cancelling all events linked to a card
- cancel attacks when beginning movement and vice versa
- keep checking range when scheduling continuous attacks
- clean previous events when a new manual order is issued

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521ebc1c648326b78585dcfca8f33f