### PR TITLE
Fix no test buttons

### DIFF
--- a/src/data/config/game_config.json
+++ b/src/data/config/game_config.json
@@ -7,5 +7,5 @@
   "max_cartas_por_tier": {"1": 0, "2": 0, "3": 0},
   "cartas_subasta_default": 5,
   "cartas_activas": [],
-  "modo_testeo": false
+  "modo_testeo": true
 }


### PR DESCRIPTION
## Summary
- enable test mode configuration by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852284146608326a2221532765b87eb