### PR TITLE
Fix mostrar controles de testeo siempre

### DIFF
--- a/src/interfas/gui.py
+++ b/src/interfas/gui.py
@@ -478,6 +478,8 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
             self.lbl_equipo_azul.config(text=f"🔵 EQUIPO AZUL: {azules or '-'}")
 
         if self.motor.modo_testeo:
+            if self.frame_testeo.winfo_ismapped() == 0:
+                self.frame_testeo.pack(fill="x", padx=10, pady=5)
             self.actualizar_controles_testeo()
             if self.frame_mover_test.winfo_ismapped() == 0:
                 self.frame_mover_test.pack(fill="x", pady=5)


### PR DESCRIPTION
## Summary
- ensure testing controls frame is packed whenever in test mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522bc3aba48326bbf5e96f50419bd5