### PR TITLE
Implementar ventana de testeo y limpiar prints

### DIFF
--- a/src/core/motor_juego.py
+++ b/src/core/motor_juego.py
@@ -24,9 +24,6 @@ class MotorJuego:
         self.config = GameConfig()
         self.modo_testeo = self.config.modo_testeo
 
-        print(f"\U0001F50D MotorJuego.__init__ - Configuraci\u00f3n:")
-        print(f"   config.modo_testeo: {self.config.modo_testeo}")
-        print(f"   self.modo_testeo: {self.modo_testeo}")
 
         self.controlador_enfrentamiento = None
         self.mapa_global = None
@@ -40,9 +37,6 @@ class MotorJuego:
             modo_testeo=self.modo_testeo
         )
 
-        print(f"\U0001F50D M\u00e9todos de testeo disponibles:")
-        print(f"   describir_proximo_paso: {hasattr(self, 'describir_proximo_paso')}")
-        print(f"   ejecutar_siguiente_paso: {hasattr(self, 'ejecutar_siguiente_paso')}")
 
 
     def iniciar(self):

--- a/src/data/config/game_config.py
+++ b/src/data/config/game_config.py
@@ -5,7 +5,6 @@ CONFIG_PATH = os.path.join(os.path.dirname(__file__), "game_config.json")
 
 class GameConfig:
     def __init__(self):
-        print(f"\U0001F50D GameConfig cargando...")
         with open(CONFIG_PATH, "r", encoding="utf-8") as f:
             data = json.load(f)
 
@@ -33,4 +32,3 @@ class GameConfig:
 
         # Modo testeo manual
         self.modo_testeo = data.get("modo_testeo", False)
-        print(f"   modo_testeo desde JSON: {self.modo_testeo}")

--- a/src/interfas/ventana_testeo.py
+++ b/src/interfas/ventana_testeo.py
@@ -1,0 +1,88 @@
+import tkinter as tk
+from tkinter import ttk
+
+class VentanaTesteo:
+    def __init__(self, motor_juego, jugador_actual_callback, on_close=None):
+        self.motor = motor_juego
+        self.jugador_actual_callback = jugador_actual_callback
+        self.on_close = on_close
+
+        self.window = tk.Toplevel()
+        self.window.title("Auto-Battler - Controles de Testeo")
+        self.window.geometry("400x300")
+        self.window.resizable(False, False)
+        self.window.attributes("-topmost", True)
+        self.window.protocol("WM_DELETE_WINDOW", self.cerrar_ventana)
+        self.window.bind("<Unmap>", self._evitar_minimizar)
+
+        screen_width = self.window.winfo_screenwidth()
+        x = screen_width - 400 - 10
+        self.window.geometry(f"400x300+{x}+0")
+
+        self._after_id = None
+
+        self._construir_widgets()
+        self.actualizar_informacion()
+
+    def _construir_widgets(self):
+        self.lbl_estado = ttk.Label(self.window, text="Estado: -")
+        self.lbl_estado.pack(anchor="w", padx=10, pady=(10, 0))
+        self.lbl_proximo = ttk.Label(self.window, text="Próximo Paso: -")
+        self.lbl_proximo.pack(anchor="w", padx=10)
+        self.lbl_turno = ttk.Label(self.window, text="Turno Activo: -")
+        self.lbl_turno.pack(anchor="w", padx=10)
+
+        ttk.Button(self.window, text="Ejecutar Siguiente Paso", command=self.ejecutar_paso).pack(pady=(5, 0))
+        ttk.Button(self.window, text="Oro Infinito", command=self.asignar_oro_infinito).pack(pady=2)
+        ttk.Button(self.window, text="Tokens Infinitos", command=self.asignar_tokens_infinitos).pack(pady=2)
+
+        self.lbl_jugador = ttk.Label(self.window, text="Jugador Actual: -")
+        self.lbl_jugador.pack(anchor="w", padx=10, pady=(10, 0))
+        self.lbl_recursos = ttk.Label(self.window, text="Oro: - | Tokens: -")
+        self.lbl_recursos.pack(anchor="w", padx=10)
+
+    def _evitar_minimizar(self, event):
+        if self.window.state() == "iconic":
+            self.window.after(0, self.window.deiconify)
+
+    def actualizar_informacion(self):
+        jugador = self.jugador_actual_callback()
+        if jugador:
+            self.lbl_jugador.config(text=f"Jugador Actual: {jugador.nombre}")
+            self.lbl_recursos.config(text=f"Oro: {jugador.oro} | Tokens: {jugador.tokens_reroll}")
+        if self.motor:
+            try:
+                proximo = self.motor.describir_proximo_paso()
+            except Exception:
+                proximo = "-"
+            self.lbl_proximo.config(text=f"Próximo Paso: {proximo}")
+            self.lbl_estado.config(text=f"Estado: {self.motor.fase_actual}")
+            turno = "-"
+            if hasattr(self.motor, "controlador_enfrentamiento") and self.motor.controlador_enfrentamiento:
+                t = self.motor.controlador_enfrentamiento.obtener_turno_activo()
+                if t:
+                    turno = t
+            self.lbl_turno.config(text=f"Turno Activo: {turno}")
+        self._after_id = self.window.after(500, self.actualizar_informacion)
+
+    def ejecutar_paso(self):
+        if self.motor:
+            self.motor.ejecutar_siguiente_paso()
+
+    def asignar_oro_infinito(self):
+        jugador = self.jugador_actual_callback()
+        if jugador:
+            jugador.oro = 999999
+
+    def asignar_tokens_infinitos(self):
+        jugador = self.jugador_actual_callback()
+        if jugador:
+            jugador.tokens_reroll = 999
+
+    def cerrar_ventana(self):
+        if self._after_id:
+            self.window.after_cancel(self._after_id)
+            self._after_id = None
+        if self.on_close:
+            self.on_close()
+        self.window.destroy()


### PR DESCRIPTION
## Summary
- limpia mensajes de depuracion en `GameConfig`, `MotorJuego` y GUI
- crea la clase `VentanaTesteo` para controles de testeo
- ajusta `AutoBattlerGUI` para abrir la nueva ventana en modo testeo
- elimina panel de testeo de la ventana principal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852388611488326933873297df5cdec