### PR TITLE
Refactor comportamientos con órdenes simuladas

### DIFF
--- a/src/game/combate/ia/ia_utilidades.py
+++ b/src/game/combate/ia/ia_utilidades.py
@@ -13,15 +13,20 @@ def obtener_info_entorno(carta, tablero):
     """
     coord = tablero.obtener_coordenada_de(carta)
     enemigos = []
+    aliados = []
 
     if coord:
         for otra_coord, otra_carta in tablero.obtener_cartas_en_rango(coord, carta.rango_ataque_actual):
-            if otra_carta and not carta.es_aliado_de(otra_carta):
-                enemigos.append(otra_carta)
+            if otra_carta:
+                if carta.es_aliado_de(otra_carta):
+                    aliados.append(otra_carta)
+                else:
+                    enemigos.append(otra_carta)
 
     return {
         "coordenada_actual": coord,
-        "enemigos_en_rango": enemigos
+        "enemigos_en_rango": enemigos,
+        "aliados": aliados
     }
 
 

--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -56,7 +56,7 @@ class GestorInteracciones:
                 "TRACE",
             )
             if carta.puede_actuar:
-                if carta.tiene_orden_manual():
+                if carta.tiene_orden_manual() or carta.tiene_orden_simulada():
                     log_evento(
                         f"📝 ORDEN DETECTADA en {carta.nombre}: {carta.orden_actual}",
                         "DEBUG",
@@ -124,8 +124,10 @@ class GestorInteracciones:
         if not orden:
             return
 
+        origen = "Manual" if not orden.get("simulada") else "SimOrden"
+        pref = "🎮" if origen == "Manual" else "🤖"
         log_evento(
-            f"⚙️ Procesando orden manual para {carta.nombre}: tipo={orden.get('tipo')}, progreso={orden.get('progreso')}",
+            f"{pref} [{origen}] Procesando orden para {carta.nombre}: tipo={orden.get('tipo')}, progreso={orden.get('progreso')}",
             "DEBUG",
         )
 
@@ -203,10 +205,15 @@ class GestorInteracciones:
 
         if orden["progreso"] == "completada":
             log_evento(
-                f"✅ Orden '{orden.get('tipo')}' completada para {carta.nombre}",
+                f"🎯 [Completar] Orden '{orden.get('tipo')}' para {carta.nombre}",
                 "DEBUG",
             )
+            simulada = orden.get("simulada")
             carta.limpiar_orden_manual()
+            if simulada:
+                log_evento("⚡ [Continuar] Evaluando siguiente orden", "DEBUG")
+                nuevas = generar_interacciones_para(carta, self.tablero)
+                self.interacciones_pendientes.extend(nuevas)
 
 
     def obtener_estadisticas(self):

--- a/src/game/comportamientos/legacy/OLD/movement_behaviors.py
+++ b/src/game/comportamientos/legacy/OLD/movement_behaviors.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from .behavior_component import BehaviorComponent
-from src.game.combate.ia.ia_utilidades import mover_carta_con_pathfinding
+from src.utils.helpers import log_evento
 
 
 class MovementBehavior(Enum):
@@ -22,47 +22,41 @@ class MovementProcessor(BehaviorComponent):
         self.tipo = tipo
 
     def ejecutar(self, carta, tablero, info_entorno) -> Optional[object]:
+        if carta.tiene_orden_manual() or carta.tiene_orden_simulada():
+            return None
+
+        destino = None
         if self.tipo == MovementBehavior.PARADO:
             return None
         if self.tipo == MovementBehavior.REGRESO:
             destino = getattr(carta, "zona_base", None)
-            if destino:
-                mover_carta_con_pathfinding(carta, destino, tablero)
-            return None
-        enemigos = info_entorno.get("enemigos_en_rango", [])
-        aliados = info_entorno.get("aliados", [])
-        if self.tipo == MovementBehavior.HUIR and enemigos:
-            # Moverse a la coordenada vecina más alejada del primer enemigo
-            from src.game.tablero.coordenada import CoordenadaHexagonal
-
+        else:
+            enemigos = info_entorno.get("enemigos_en_rango", [])
+            aliados = info_entorno.get("aliados", [])
             origen = tablero.obtener_coordenada_de(carta)
-            if origen and enemigos[0].coordenada:
-                vecinos = [v for v in origen.vecinos() if tablero.esta_vacia(v)]
-                if vecinos:
-                    vecinos.sort(
-                        key=lambda c: c.distancia(enemigos[0].coordenada),
-                        reverse=True,
-                    )
-                    mover_carta_con_pathfinding(carta, vecinos[0], tablero)
-            return None
-        if self.tipo == MovementBehavior.SEGUIDOR:
-            if aliados:
+
+            if self.tipo == MovementBehavior.HUIR and enemigos:
+                if origen and enemigos[0].coordenada:
+                    vecinos = [v for v in origen.vecinos() if tablero.esta_vacia(v)]
+                    if vecinos:
+                        vecinos.sort(key=lambda c: c.distancia(enemigos[0].coordenada), reverse=True)
+                        destino = vecinos[0]
+            elif self.tipo == MovementBehavior.SEGUIDOR and aliados:
                 aliado = aliados[0]
                 if aliado.coordenada:
-                    mover_carta_con_pathfinding(carta, aliado.coordenada, tablero)
-            return None
-        if self.tipo in {MovementBehavior.EXPLORADOR, MovementBehavior.CAZADOR}:
-            origen = tablero.obtener_coordenada_de(carta)
-            if not origen:
-                return None
-            for vec in origen.vecinos():
-                if tablero.esta_vacia(vec):
-                    mover_carta_con_pathfinding(carta, vec, tablero)
-                    break
-            return None
-        if self.tipo == MovementBehavior.MERODEADOR:
-            base = getattr(carta, "zona_base", None)
-            if base:
-                mover_carta_con_pathfinding(carta, base, tablero)
-            return None
+                    destino = aliado.coordenada
+            elif self.tipo in {MovementBehavior.EXPLORADOR, MovementBehavior.CAZADOR}:
+                if origen:
+                    for vec in origen.vecinos():
+                        if tablero.esta_vacia(vec):
+                            destino = vec
+                            break
+            elif self.tipo == MovementBehavior.MERODEADOR:
+                base = getattr(carta, "zona_base", None)
+                if base:
+                    destino = base
+
+        if destino is not None:
+            carta.marcar_orden_simulada("mover", destino)
+            log_evento(f"🤖 [SimOrden] {carta.nombre} genera movimiento a {destino}", "DEBUG")
         return None


### PR DESCRIPTION
## Summary
- allow cards to track manual and simulated orders
- GestorInteracciones procesa ambas usando el mismo camino
- MovementProcessor now generates simulated move orders instead of moving directly
- environment info now includes allies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685257c92e188326842ab4e0dff1ad92