### PR TITLE
Arregla ruido de logs y ciclo de comportamiento

### DIFF
--- a/src/game/combate/ia/ia_utilidades.py
+++ b/src/game/combate/ia/ia_utilidades.py
@@ -84,6 +84,8 @@ def mover_carta_con_pathfinding(
     origen = mapa.obtener_coordenada_de(carta)
     if origen is None:
         log_evento(f"❌ No se encontró coordenada de {carta.nombre}", "DEBUG")
+        if on_finish:
+            on_finish()
         return False
 
     # Al iniciar un movimiento cancelamos eventos de ataque previos
@@ -103,6 +105,8 @@ def mover_carta_con_pathfinding(
     ruta = _buscar_ruta(mapa, origen, destino)
     if not ruta:
         log_evento("⚠️ Ruta no encontrada", "DEBUG")
+        if on_finish:
+            on_finish()
         return False
 
     log_evento(
@@ -120,6 +124,8 @@ def mover_carta_con_pathfinding(
             origen = paso
             if on_step:
                 on_step()
+        if on_finish:
+            on_finish()
         return True
 
     delay = max(0.1, 1.0 / max(0.01, getattr(carta, "velocidad_movimiento", 1.0)))
@@ -184,7 +190,7 @@ def atacar_si_en_rango(carta_atacante, carta_objetivo):
     return True
 
 
-def iniciar_ataque_continuo(atacante, objetivo, mapa, motor, on_step=None):
+def iniciar_ataque_continuo(atacante, objetivo, mapa, motor, on_step=None, on_finish=None):
     """Ejecuta ataques automáticos mientras el objetivo esté vivo y visible.
 
     ``on_step`` es una función opcional que se llamará tras cada acción para
@@ -203,6 +209,8 @@ def iniciar_ataque_continuo(atacante, objetivo, mapa, motor, on_step=None):
                 atacante.cancelar_evento_activo("ataque", motor)
             except AttributeError:
                 pass
+            if on_finish:
+                on_finish()
             return
 
         if atacante.coordenada is None or objetivo.coordenada is None:
@@ -210,6 +218,8 @@ def iniciar_ataque_continuo(atacante, objetivo, mapa, motor, on_step=None):
                 atacante.cancelar_evento_activo("ataque", motor)
             except AttributeError:
                 pass
+            if on_finish:
+                on_finish()
             return
 
         distancia = atacante.coordenada.distancia(objetivo.coordenada)

--- a/src/game/combate/motor/motor_tiempo_real.py
+++ b/src/game/combate/motor/motor_tiempo_real.py
@@ -291,7 +291,7 @@ class MotorTiempoReal:
 
         log_evento(
             f"⚙️ Procesando {len(componentes)} componentes: {[id_comp for id_comp, _ in componentes]}",
-            "DEBUG",
+            "TRACE",
         )
 
         for id_componente, componente in componentes:

--- a/src/game/comportamientos/legacy/OLD/movement_behaviors.py
+++ b/src/game/comportamientos/legacy/OLD/movement_behaviors.py
@@ -26,10 +26,14 @@ class MovementProcessor(BehaviorComponent):
             carta.tiene_orden_manual()
             or carta.tiene_orden_simulada()
             or carta.tiene_evento_activo("movimiento")
+            or (
+                carta.orden_actual is not None
+                and carta.orden_actual.get("progreso") == "ejecutando"
+            )
         ):
             log_evento(
                 f"⏳ {carta.nombre} omite nueva orden de movimiento (en curso)",
-                "DEBUG",
+                "TRACE",
             )
             return None
 

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -41,8 +41,10 @@ def guardar_json(datos, ruta_archivo):
 
 def log_evento(mensaje, nivel="INFO"):
     """Registra un evento en consola y opcionalmente en archivo"""
-    if nivel == "TRACE":
-        # Los mensajes TRACE siguen siendo suprimidos para evitar ruido excesivo
+    if nivel == "TRACE" or (
+        nivel == "DEBUG" and any(x in mensaje for x in ["motor", "Tick", "Procesando"])
+    ):
+        # Suprimir trazas y depuración excesiva del motor
         return
 
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Summary
- filtra mensajes de depuración en `log_evento`
- baja a `TRACE` los logs de procesamiento en el motor y el gestor de interacciones
- mantiene órdenes manuales hasta que finaliza su ejecución
- asegura llamadas a `on_finish` en movimientos y ataques continuos
- evita nuevas órdenes mientras haya una en ejecución

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853672b609083268ef858b15aa1ce39