### PR TITLE
Fix manual move timing

### DIFF
--- a/src/game/combate/interacciones/gestor_interacciones.py
+++ b/src/game/combate/interacciones/gestor_interacciones.py
@@ -144,8 +144,14 @@ class GestorInteracciones:
             "TRACE",
         )
 
-        if orden["progreso"] == "pendiente":
-            orden["progreso"] = "ejecutando"
+        # Ejecutar la orden una única vez para que los eventos programados
+        # (movimiento o ataque) puedan respetar su propio timing. En iteraciones
+        # posteriores simplemente se espera a que finalicen.
+        if orden["progreso"] != "pendiente":
+            # Ya se ha iniciado la ejecución previamente
+            return
+
+        orden["progreso"] = "ejecutando"
 
         if self.motor:
             try:


### PR DESCRIPTION
## Summary
- prevent repeated processing of manual orders
- keep scheduled move events running so card speed is respected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537714e0b883268ba1a9e65dad966a