### PR TITLE
Rename modules and classes to English

### DIFF
--- a/src/core/jugador.py
+++ b/src/core/jugador.py
@@ -3,7 +3,7 @@ Clase Jugador - Representa a un jugador en el auto-battler
 """
 
 from src.utils.helpers import log_evento, validar_rango
-from src.game.tablero.tablero_hexagonal import TableroHexagonal
+from src.game.board.hex_board import HexBoard
 from src.game.combate.configuracion_tiempo_real import configurador_tiempo_real
 
 
@@ -27,7 +27,7 @@ class Jugador:
         # Tablero hexagonal individual (NUEVO)
         if radio_tablero is None:
             radio_tablero = configurador_tiempo_real.mapas.radio_mapa_individual
-        self.tablero = TableroHexagonal(radio=radio_tablero)
+        self.tablero = HexBoard(radio=radio_tablero)
 
         # Inventario y cartas (ACTUALIZADO)
         self.cartas_banco = []  # Cartas guardadas (fuera del tablero)

--- a/src/core/motor_juego.py
+++ b/src/core/motor_juego.py
@@ -3,7 +3,7 @@ import random
 
 from src.core.jugador import Jugador
 from src.data.config.game_config import GameConfig
-from src.game.cartas.manager_cartas import manager_cartas
+from src.game.cards.card_manager import card_manager
 from src.game.combate.interacciones.gestor_interacciones import GestorInteracciones
 from src.game.combate.mapa.mapa_global import MapaGlobal
 from src.game.combate.motor.motor_tiempo_real import MotorTiempoReal
@@ -51,8 +51,8 @@ class MotorJuego:
         log_evento("🎮 Iniciando juego...")
 
         # AGREGAR: Cargar base de datos de cartas
-        if not manager_cartas.cartas_cargadas:
-            manager_cartas.cargar_cartas()
+        if not card_manager.cartas_cargadas:
+            card_manager.cargar_cartas()
 
         self._entregar_cartas_iniciales()
 
@@ -87,9 +87,9 @@ class MotorJuego:
             mapa.ubicar_jugador_en_zona(jugador, color)
 
         # Aplicar comportamientos asignados a las cartas
-        from src.game.cartas.carta_base import CartaBase
+        from src.game.cards.base_card import BaseCard
         for carta in mapa.tablero.celdas.values():
-            if isinstance(carta, CartaBase) and getattr(carta, "comportamiento_asignado", None):
+            if isinstance(carta, BaseCard) and getattr(carta, "comportamiento_asignado", None):
                 carta.modo_control = carta.comportamiento_asignado
                 log_evento(
                     f"🎯 {carta.nombre} inicia como '{carta.modo_control}'",
@@ -220,7 +220,7 @@ class MotorJuego:
         tier = random.choice([1, 2])
         log_evento(f"🎁 Entregando carta inicial de tier {tier} a todos los jugadores")
         for jugador in self.jugadores_vivos:
-            carta = manager_cartas.obtener_carta_aleatoria_tier(tier)
+            carta = card_manager.obtener_carta_aleatoria_tier(tier)
             if carta:
                 jugador.agregar_carta_al_banco(carta)
             else:

--- a/src/game/board/hex_board.py
+++ b/src/game/board/hex_board.py
@@ -1,13 +1,13 @@
 from typing import Dict, Optional, List
-from src.game.tablero.coordenada import CoordenadaHexagonal
+from src.game.board.hex_coordinate import HexCoordinate
 from src.utils.helpers import log_evento
 
 
-class TableroHexagonal:
+class HexBoard:
     def __init__(self, radio: int = 2):
         self.radio = radio
-        self.centro = CoordenadaHexagonal(0, 0)
-        self.celdas: Dict[CoordenadaHexagonal, Optional[any]] = {}
+        self.centro = HexCoordinate(0, 0)
+        self.celdas: Dict[HexCoordinate, Optional[any]] = {}
         self._generar_celdas()
 
     def _generar_celdas(self):
@@ -19,10 +19,10 @@ class TableroHexagonal:
 
         log_evento(f"Tablero generado: {len(self.celdas)} celdas")
 
-    def obtener_celda(self, coordenada: CoordenadaHexagonal):
+    def obtener_celda(self, coordenada: HexCoordinate):
         return self.celdas.get(coordenada)
 
-    def colocar_carta(self, coordenada: CoordenadaHexagonal, carta):
+    def colocar_carta(self, coordenada: HexCoordinate, carta):
         if coordenada in self.celdas:
             self.celdas[coordenada] = carta
             if hasattr(carta, "coordenada"):
@@ -48,7 +48,7 @@ class TableroHexagonal:
 
         return resultado
 
-    def obtener_coordenada_de(self, carta) -> Optional[CoordenadaHexagonal]:
+    def obtener_coordenada_de(self, carta) -> Optional[HexCoordinate]:
         for coord, obj in self.celdas.items():
             if obj is carta:
                 return coord
@@ -57,19 +57,19 @@ class TableroHexagonal:
     def obtener_cartas(self) -> List:
         return [carta for carta in self.celdas.values() if carta is not None]
 
-    def obtener_carta_en(self, coordenada: CoordenadaHexagonal):
+    def obtener_carta_en(self, coordenada: HexCoordinate):
         return self.celdas.get(coordenada)
 
-    def coordenadas_ocupadas(self) -> List[CoordenadaHexagonal]:
+    def coordenadas_ocupadas(self) -> List[HexCoordinate]:
         return [coord for coord, carta in self.celdas.items() if carta is not None]
 
-    def coordenadas_libres(self) -> List[CoordenadaHexagonal]:
+    def coordenadas_libres(self) -> List[HexCoordinate]:
         return [coord for coord, carta in self.celdas.items() if carta is None]
 
-    def esta_vacia(self, coordenada: CoordenadaHexagonal) -> bool:
+    def esta_vacia(self, coordenada: HexCoordinate) -> bool:
         return self.celdas.get(coordenada) is None
 
-    def esta_dentro_del_tablero(self, coord: CoordenadaHexagonal) -> bool:
+    def esta_dentro_del_tablero(self, coord: HexCoordinate) -> bool:
         return coord in self.celdas
 
     def limpiar_tablero(self):
@@ -96,11 +96,11 @@ class TableroHexagonal:
         """Cuenta el número total de cartas en el tablero"""
         return len([carta for carta in self.celdas.values() if carta is not None])
 
-    def obtener_coordenadas_disponibles(self) -> List[CoordenadaHexagonal]:
+    def obtener_coordenadas_disponibles(self) -> List[HexCoordinate]:
         """Alias para coordenadas_libres() - mantiene compatibilidad con jugador.py"""
         return self.coordenadas_libres()
 
-    def mover_carta(self, desde: CoordenadaHexagonal, hacia: CoordenadaHexagonal) -> bool:
+    def mover_carta(self, desde: HexCoordinate, hacia: HexCoordinate) -> bool:
         """Mueve una carta de una coordenada a otra"""
         # Verificar que ambas coordenadas existen en el tablero
         if desde not in self.celdas or hacia not in self.celdas:
@@ -150,7 +150,7 @@ class TableroHexagonal:
             'centro': str(self.centro)
         }
 
-    def intercambiar_cartas(self, coord1: CoordenadaHexagonal, coord2: CoordenadaHexagonal) -> bool:
+    def intercambiar_cartas(self, coord1: HexCoordinate, coord2: HexCoordinate) -> bool:
         """Intercambia las cartas en dos posiciones (bonus method)"""
         if coord1 not in self.celdas or coord2 not in self.celdas:
             log_evento(f"❌ Coordenadas inválidas para intercambiar: {coord1} ↔ {coord2}")
@@ -173,14 +173,14 @@ class TableroHexagonal:
                 resultado.append((coord, carta))
         return resultado
 
-    def buscar_carta(self, carta_objetivo) -> Optional[CoordenadaHexagonal]:
+    def buscar_carta(self, carta_objetivo) -> Optional[HexCoordinate]:
         """Busca una carta específica y retorna su coordenada"""
         for coord, carta in self.celdas.items():
             if carta is carta_objetivo:
                 return coord
         return None
 
-    def obtener_densidad_area(self, centro: CoordenadaHexagonal, radio: int) -> float:
+    def obtener_densidad_area(self, centro: HexCoordinate, radio: int) -> float:
         """Calcula la densidad de cartas en un área específica"""
         celdas_area = centro.obtener_area(radio)
         celdas_validas = [c for c in celdas_area if c in self.celdas]

--- a/src/game/board/hex_coordinate.py
+++ b/src/game/board/hex_coordinate.py
@@ -3,24 +3,24 @@ from typing import List
 
 
 @dataclass(frozen=True)
-class CoordenadaHexagonal:
+class HexCoordinate:
     q: int
     r: int
 
-    def __add__(self, otro: "CoordenadaHexagonal") -> "CoordenadaHexagonal":
-        return CoordenadaHexagonal(self.q + otro.q, self.r + otro.r)
+    def __add__(self, otro: "HexCoordinate") -> "HexCoordinate":
+        return HexCoordinate(self.q + otro.q, self.r + otro.r)
 
-    def __sub__(self, otro: "CoordenadaHexagonal") -> "CoordenadaHexagonal":
-        return CoordenadaHexagonal(self.q - otro.q, self.r - otro.r)
+    def __sub__(self, otro: "HexCoordinate") -> "HexCoordinate":
+        return HexCoordinate(self.q - otro.q, self.r - otro.r)
 
     def s(self) -> int:
         return -self.q - self.r
 
-    def distancia(self, otra: "CoordenadaHexagonal") -> int:
+    def distancia(self, otra: "HexCoordinate") -> int:
         """Devuelve la distancia hexagonal entre dos coordenadas."""
         return int((abs(self.q - otra.q) + abs(self.r - otra.r) + abs(self.s() - otra.s())) / 2)
 
-    def distancia_a(self, otra: "CoordenadaHexagonal") -> int:
+    def distancia_a(self, otra: "HexCoordinate") -> int:
         """Otra forma de calcular la distancia, usando max de diferencias."""
         return max(
             abs(self.q - otra.q),
@@ -28,21 +28,21 @@ class CoordenadaHexagonal:
             abs(self.s() - otra.s())
         )
 
-    def obtener_area(self, radio: int) -> List["CoordenadaHexagonal"]:
+    def obtener_area(self, radio: int) -> List["HexCoordinate"]:
         """Devuelve todas las coordenadas dentro de un radio desde esta coordenada."""
         resultados = []
         for dq in range(-radio, radio + 1):
             for dr in range(max(-radio, -dq - radio), min(radio, -dq + radio) + 1):
-                resultados.append(CoordenadaHexagonal(self.q + dq, self.r + dr))
+                resultados.append(HexCoordinate(self.q + dq, self.r + dr))
         return resultados
 
-    def vecinos(self) -> List["CoordenadaHexagonal"]:
+    def vecinos(self) -> List["HexCoordinate"]:
         direcciones = [
             (1, 0), (1, -1), (0, -1),
             (-1, 0), (-1, 1), (0, 1)
         ]
         return [
-            CoordenadaHexagonal(self.q + dq, self.r + dr)
+            HexCoordinate(self.q + dq, self.r + dr)
             for dq, dr in direcciones
         ]
 

--- a/src/game/cards/base_card.py
+++ b/src/game/cards/base_card.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Any
 from src.game.combate.interacciones.interaccion_modelo import TipoInteraccion, Interaccion
 from src.utils.helpers import log_evento
 
-class Habilidad:
+class Ability:
     """Representa una habilidad de carta"""
 
     def __init__(self, datos_habilidad: Dict[str, Any]):
@@ -32,20 +32,20 @@ class Habilidad:
                             if k not in ['nombre', 'tipo', 'descripcion', 'costo_mana',
                                          'cooldown', 'rango', 'duracion', 'trigger', 'area']}
 
-    def puede_usar(self) -> bool:
+    def can_use(self) -> bool:
         """Verifica si la habilidad puede ser usada"""
         if self.tipo == 'activa':
             return self.cooldown_actual <= 0
         return True
 
 
-    def usar(self):
+    def use(self):
         """Marca la habilidad como usada (inicia cooldown)"""
         if self.tipo == 'activa':
             self.cooldown_actual = self.cooldown
             log_evento(f"Habilidad '{self.nombre}' usada (Cooldown: {self.cooldown})")
 
-    def reducir_cooldown(self):
+    def reduce_cooldown(self):
         """Reduce el cooldown en 1"""
         if self.cooldown_actual > 0:
             self.cooldown_actual -= 1
@@ -57,7 +57,7 @@ class Habilidad:
         return f"Habilidad(nombre='{self.nombre}', tipo='{self.tipo}')"
 
 
-class CartaBase:
+class BaseCard:
     """Clase base para todas las cartas del juego"""
 
     def __init__(self, datos_carta: Dict[str, Any]):
@@ -106,7 +106,7 @@ class CartaBase:
         self.mana_actual = 0
 
         # Habilidades
-        self.habilidades: List[Habilidad] = []
+        self.habilidades: List[Ability] = []
         self._cargar_habilidades(datos_carta.get('habilidades', []))
 
         # Estado de la carta
@@ -162,7 +162,7 @@ class CartaBase:
     def _cargar_habilidades(self, habilidades_data: List[Dict[str, Any]]):
         """Carga las habilidades desde los datos JSON"""
         for hab_data in habilidades_data:
-            habilidad = Habilidad(hab_data)
+            habilidad = Ability(hab_data)
             self.habilidades.append(habilidad)
 
     # === MÉTODOS DE VIDA Y ESTADO ===
@@ -201,8 +201,8 @@ class CartaBase:
             if getattr(self, "tablero", None) and getattr(self, "coordenada", None):
                 try:
                     self.tablero.quitar_carta(self.coordenada)
-                    from src.game.cartas.manager_cartas import manager_cartas
-                    manager_cartas.devolver_carta_al_pool(self)
+                    from src.game.cards.card_manager import card_manager
+                    card_manager.devolver_carta_al_pool(self)
                 except Exception:
                     pass
 
@@ -490,7 +490,7 @@ class CartaBase:
         self.comportamiento_asignado = tipo
         log_evento(f"🔧 {self.nombre} configurado como '{tipo}'")
         return f"✅ Comportamiento '{tipo}' asignado"
-    def obtener_habilidades_disponibles(self) -> List[Habilidad]:
+    def obtener_habilidades_disponibles(self) -> List[Ability]:
         """Retorna lista de habilidades que pueden ser usadas"""
         return [hab for i, hab in enumerate(self.habilidades)
                 if self.puede_usar_habilidad(i)]
@@ -543,5 +543,5 @@ class CartaBase:
 
     def __repr__(self):
         """Representación para debugging"""
-        return f"CartaBase(id={self.id}, nombre='{self.nombre}', tier={self.tier})"
+        return f"BaseCard(id={self.id}, nombre='{self.nombre}', tier={self.tier})"
 

--- a/src/game/cards/card_fusion.py
+++ b/src/game/cards/card_fusion.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from src.utils.helpers import log_evento
 
 
-def aplicar_fusiones(tablero, banco: list) -> list[str]:
+def apply_fusions(tablero, banco: list) -> list[str]:
     """Aplica fusiones de cartas entre tablero y banco de forma controlada."""
     eventos = []
     iteraciones = 0

--- a/src/game/combate/mapa/generador_mapa.py
+++ b/src/game/combate/mapa/generador_mapa.py
@@ -1,6 +1,6 @@
 from .zona_mapa import ZonaMapa
 from .utilidades_mapa import generar_hexagono_regular
-from src.game.tablero.coordenada import CoordenadaHexagonal
+from src.game.board.hex_coordinate import HexCoordinate
 from src.game.combate.configuracion_tiempo_real import configurador_tiempo_real
 import random
 
@@ -16,13 +16,13 @@ class GeneradorMapa:
         self.zonas_rojas = []
         self.zonas_azules = []
 
-    def _hex_cabe(self, centro: CoordenadaHexagonal) -> bool:
+    def _hex_cabe(self, centro: HexCoordinate) -> bool:
         for c in centro.obtener_area(self.radio_zona):
             if c not in self.tablero.celdas:
                 return False
         return True
 
-    def _centro_valido(self, centro: CoordenadaHexagonal, zonas_existentes: list[ZonaMapa], separacion: int) -> bool:
+    def _centro_valido(self, centro: HexCoordinate, zonas_existentes: list[ZonaMapa], separacion: int) -> bool:
         if not self._hex_cabe(centro):
             return False
         for zona in zonas_existentes:
@@ -30,7 +30,7 @@ class GeneradorMapa:
                 return False
         return True
 
-    def _obtener_centro_random(self, zonas_existentes: list[ZonaMapa], separacion: int) -> CoordenadaHexagonal | None:
+    def _obtener_centro_random(self, zonas_existentes: list[ZonaMapa], separacion: int) -> HexCoordinate | None:
         candidatos = list(self.tablero.celdas.keys())
         random.shuffle(candidatos)
         for cand in candidatos:

--- a/src/game/combate/mapa/mapa_global.py
+++ b/src/game/combate/mapa/mapa_global.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional
-from src.game.tablero.coordenada import CoordenadaHexagonal
-from src.game.tablero.tablero_hexagonal import TableroHexagonal
+from src.game.board.hex_coordinate import HexCoordinate
+from src.game.board.hex_board import HexBoard
 from src.game.combate.mapa.zona_mapa import ZonaMapa
 from src.game.combate.mapa.generador_mapa import GeneradorMapa
 from src.game.combate.configuracion_tiempo_real import configurador_tiempo_real
@@ -16,8 +16,8 @@ class MapaGlobal:
         if cantidad_parejas is None:
             cantidad_parejas = configurador_tiempo_real.mapas.cantidad_parejas
 
-        self.tablero = TableroHexagonal(radio=radio)
-        self.celdas: Dict[CoordenadaHexagonal, Optional[object]] = self.tablero.celdas
+        self.tablero = HexBoard(radio=radio)
+        self.celdas: Dict[HexCoordinate, Optional[object]] = self.tablero.celdas
         self.zonas_rojas: list[ZonaMapa] = []
         self.zonas_azules: list[ZonaMapa] = []
         self._generar_zonas(celdas_por_zona, cantidad_parejas)
@@ -28,7 +28,7 @@ class MapaGlobal:
         self.zonas_rojas = generador.zonas_rojas
         self.zonas_azules = generador.zonas_azules
 
-    def obtener_color_en(self, coord: CoordenadaHexagonal) -> Optional[str]:
+    def obtener_color_en(self, coord: HexCoordinate) -> Optional[str]:
         for zona in self.zonas_rojas:
             if coord in zona.coordenadas:
                 return "rojo"

--- a/src/game/combate/mapa/utilidades_mapa.py
+++ b/src/game/combate/mapa/utilidades_mapa.py
@@ -1,8 +1,8 @@
 from typing import Set
-from src.game.tablero.coordenada import CoordenadaHexagonal
+from src.game.board.hex_coordinate import HexCoordinate
 
 
-def generar_hexagonos_contiguos(origen: CoordenadaHexagonal, cantidad: int, disponibles: set = None) -> Set[CoordenadaHexagonal]:
+def generar_hexagonos_contiguos(origen: HexCoordinate, cantidad: int, disponibles: set = None) -> Set[HexCoordinate]:
     seleccionadas = {origen}
     frontera = [origen]
 
@@ -21,6 +21,6 @@ def generar_hexagonos_contiguos(origen: CoordenadaHexagonal, cantidad: int, disp
     return seleccionadas
 
 
-def generar_hexagono_regular(centro: CoordenadaHexagonal, radio: int) -> Set[CoordenadaHexagonal]:
+def generar_hexagono_regular(centro: HexCoordinate, radio: int) -> Set[HexCoordinate]:
     """Genera un conjunto de coordenadas que forman un hexágono regular."""
     return set(centro.obtener_area(radio))

--- a/src/game/combate/mapa/zona_mapa.py
+++ b/src/game/combate/mapa/zona_mapa.py
@@ -1,10 +1,10 @@
 from typing import Set, Optional
-from src.game.tablero.coordenada import CoordenadaHexagonal
+from src.game.board.hex_coordinate import HexCoordinate
 from src.utils.helpers import log_evento
 
 
 class ZonaMapa:
-    def __init__(self, color: str, coordenadas: set, pareja_id: int, centro: CoordenadaHexagonal):
+    def __init__(self, color: str, coordenadas: set, pareja_id: int, centro: HexCoordinate):
         self.color = color
         self.coordenadas = coordenadas
         self.pareja_id = pareja_id
@@ -17,15 +17,15 @@ class ZonaMapa:
                     return True
         return False
 
-    def obtener_coordenada_libre(self, tablero) -> Optional[CoordenadaHexagonal]:
+    def obtener_coordenada_libre(self, tablero) -> Optional[HexCoordinate]:
         for coord in self.coordenadas:
             if tablero.esta_vacia(coord):
                 return coord
         return None
 
-    def convertir_a_global(self, coord_local: CoordenadaHexagonal) -> CoordenadaHexagonal:
+    def convertir_a_global(self, coord_local: HexCoordinate) -> HexCoordinate:
         """Convierte una coordenada local (tablero individual) a coord. global en esta zona."""
-        coord_global = CoordenadaHexagonal(
+        coord_global = HexCoordinate(
             self.centro.q + coord_local.q, self.centro.r + coord_local.r
         )
         log_evento(

--- a/src/game/combate/motor/motor_tiempo_real.py
+++ b/src/game/combate/motor/motor_tiempo_real.py
@@ -418,8 +418,8 @@ class MotorTiempoReal:
                 if getattr(carta, "vida_actual", 1) <= 0 or not getattr(carta, "viva", True):
                     mapa_global.tablero.quitar_carta(coord)
                     try:
-                        from src.game.cartas.manager_cartas import manager_cartas
-                        manager_cartas.devolver_carta_al_pool(carta)
+                        from src.game.cards.card_manager import card_manager
+                        card_manager.devolver_carta_al_pool(carta)
                     except Exception:
                         pass
                     try:

--- a/src/game/comportamientos/legacy/OLD/behavior_utils.py
+++ b/src/game/comportamientos/legacy/OLD/behavior_utils.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
-from src.game.tablero.coordenada import CoordenadaHexagonal
+from src.game.board.hex_coordinate import HexCoordinate
 
 
-def calcular_zona_base(carta) -> Optional[CoordenadaHexagonal]:
+def calcular_zona_base(carta) -> Optional[HexCoordinate]:
     return getattr(carta.duenio, "zona_base", None)
 
 

--- a/src/game/tienda/sistema_subastas.py
+++ b/src/game/tienda/sistema_subastas.py
@@ -3,7 +3,7 @@ SistemaSubastas - Gestión de subastas públicas por ronda durante la fase de pr
 """
 
 from typing import List, Dict, Optional
-from src.game.cartas.manager_cartas import manager_cartas
+from src.game.cards.card_manager import card_manager
 from src.utils.helpers import log_evento
 from src.data.config.game_config import GameConfig
 
@@ -24,7 +24,7 @@ class SistemaSubastas:
         log_evento(f"🏛️ Generando subasta con {cantidad} cartas:")
 
         for i in range(cantidad):
-            cartas = manager_cartas.obtener_cartas_aleatorias_por_nivel(nivel_jugador=5, cantidad=1)
+            cartas = card_manager.obtener_cartas_aleatorias_por_nivel(nivel_jugador=5, cantidad=1)
             if cartas:
                 carta = cartas[0]
                 self.cartas_subastadas[carta.id] = {"carta": carta, "mejor_oferta": 0, "jugador": None}
@@ -65,7 +65,7 @@ class SistemaSubastas:
                 ganador.agregar_carta_al_banco(carta)
                 log_evento(f"🏆 {ganador.nombre} gana {carta.nombre} por {monto} oro")
             else:
-                manager_cartas.devolver_carta_al_pool(carta)
+                card_manager.devolver_carta_al_pool(carta)
                 log_evento(f"🔁 {carta.nombre} no fue vendida, vuelve al pool")
 
     def ver_estado_actual(self) -> List[str]:

--- a/src/game/tienda/tienda_individual.py
+++ b/src/game/tienda/tienda_individual.py
@@ -3,8 +3,8 @@ TiendaIndividual - Sistema de tienda privada por jugador durante la fases de pre
 """
 
 from typing import List, Optional
-from src.game.cartas.manager_cartas import manager_cartas
-from src.game.cartas.fusion_cartas import aplicar_fusiones
+from src.game.cards.card_manager import card_manager
+from src.game.cards.card_fusion import apply_fusions
 from src.utils.helpers import log_evento
 
 
@@ -19,9 +19,9 @@ class TiendaIndividual:
         """Genera nuevas cartas según el nivel del jugador"""
         # Devolver cartas actuales al pool
         for carta in self.cartas_disponibles:
-            manager_cartas.devolver_carta_al_pool(carta)
+            card_manager.devolver_carta_al_pool(carta)
 
-        self.cartas_disponibles = manager_cartas.obtener_cartas_aleatorias_por_nivel(
+        self.cartas_disponibles = card_manager.obtener_cartas_aleatorias_por_nivel(
             nivel_jugador=self.jugador.nivel,
             cantidad=self.cantidad_cartas
         )
@@ -53,7 +53,7 @@ class TiendaIndividual:
         self.jugador.agregar_carta_al_banco(carta)
         self.cartas_disponibles.pop(indice)
 
-        eventos = aplicar_fusiones(self.jugador.tablero, self.jugador.cartas_banco)
+        eventos = apply_fusions(self.jugador.tablero, self.jugador.cartas_banco)
         for ev in eventos:
             log_evento(f"🔧 {ev}")
 
@@ -69,7 +69,7 @@ class TiendaIndividual:
 
         # Devolver al pool las cartas que no fueron compradas
         for carta in self.cartas_disponibles:
-            manager_cartas.devolver_carta_al_pool(carta)
+            card_manager.devolver_carta_al_pool(carta)
 
         # Vaciar la tienda
         self.cartas_disponibles.clear()
@@ -81,7 +81,7 @@ class TiendaIndividual:
     def rellenar_tienda(self):
         """Genera nuevas cartas para llenar los espacios faltantes"""
         faltantes = self.cantidad_cartas - len(self.cartas_disponibles)
-        nuevas = manager_cartas.obtener_cartas_aleatorias_por_nivel(
+        nuevas = card_manager.obtener_cartas_aleatorias_por_nivel(
             nivel_jugador=self.jugador.nivel,
             cantidad=faltantes
         )

--- a/src/interfaces/gui/main_window.py
+++ b/src/interfaces/gui/main_window.py
@@ -890,8 +890,8 @@ Tokens Reroll: {self.jugador_actual.tokens_reroll}"""
         if not sel or sel[0] >= len(self._panel_coords):
             return
         origen = self._panel_coords[sel[0]]
-        from src.game.tablero.coordenada import CoordenadaHexagonal
-        destino = CoordenadaHexagonal(q, r)
+        from src.game.board.hex_coordinate import HexCoordinate
+        destino = HexCoordinate(q, r)
         tablero = self.motor.mapa_global.tablero
         if tablero.mover_carta(origen, destino):
             self.actualizar_interfaz()

--- a/src/interfaces/gui/widgets/hex_canvas.py
+++ b/src/interfaces/gui/widgets/hex_canvas.py
@@ -124,7 +124,7 @@ class InterfazMapaGlobal(ttk.Frame):
 
     def _hex_round(self, q, r):
         """Redondea coordenadas axiales flotantes a enteras"""
-        from src.game.tablero.coordenada import CoordenadaHexagonal
+        from src.game.board.hex_coordinate import HexCoordinate
 
         x = q
         z = r
@@ -145,7 +145,7 @@ class InterfazMapaGlobal(ttk.Frame):
         else:
             rz = -rx - ry
 
-        return CoordenadaHexagonal(int(rx), int(rz))
+        return HexCoordinate(int(rx), int(rz))
 
     def pixel_to_hex(self, x, y):
         """Convierte coordenadas de pixel (con offset) a hexágono del mapa."""

--- a/src/utils/hex_utils.py
+++ b/src/utils/hex_utils.py
@@ -1,8 +1,8 @@
 import math
-from src.game.tablero.coordenada import CoordenadaHexagonal
+from src.game.board.hex_coordinate import HexCoordinate
 
 
-def hex_round(q: float, r: float) -> CoordenadaHexagonal:
+def hex_round(q: float, r: float) -> HexCoordinate:
     x = q
     z = r
     y = -x - z
@@ -18,10 +18,10 @@ def hex_round(q: float, r: float) -> CoordenadaHexagonal:
         ry = -rx - rz
     else:
         rz = -rx - ry
-    return CoordenadaHexagonal(int(rx), int(rz))
+    return HexCoordinate(int(rx), int(rz))
 
 
-def pixel_to_hex(x: float, y: float, hex_size: int, offset: tuple[int, int] = (0, 0)) -> CoordenadaHexagonal:
+def pixel_to_hex(x: float, y: float, hex_size: int, offset: tuple[int, int] = (0, 0)) -> HexCoordinate:
     px = x - offset[0]
     py = y - offset[1]
     q = (2 / 3 * px) / hex_size
@@ -29,7 +29,7 @@ def pixel_to_hex(x: float, y: float, hex_size: int, offset: tuple[int, int] = (0
     return hex_round(q, r)
 
 
-def hex_to_pixel(coord: CoordenadaHexagonal, hex_size: int, offset: tuple[int, int] = (0, 0)) -> tuple[float, float]:
+def hex_to_pixel(coord: HexCoordinate, hex_size: int, offset: tuple[int, int] = (0, 0)) -> tuple[float, float]:
     x = hex_size * (3 / 2 * coord.q)
     y = hex_size * (math.sqrt(3) / 2 * coord.q + math.sqrt(3) * coord.r)
     return x + offset[0], y + offset[1]

--- a/tests/test_carta_muerta.py
+++ b/tests/test_carta_muerta.py
@@ -3,15 +3,15 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from src.game.tablero.tablero_hexagonal import TableroHexagonal
-from src.game.tablero.coordenada import CoordenadaHexagonal
-from src.game.cartas.carta_base import CartaBase
+from src.game.board.hex_board import HexBoard
+from src.game.board.hex_coordinate import HexCoordinate
+from src.game.cards.base_card import BaseCard
 
 
 def test_carta_muerta_se_remueve_del_tablero():
-    carta = CartaBase({'id': 1, 'nombre': 'Test', 'stats': {'vida': 5, 'dano_fisico': 1}})
-    tablero = TableroHexagonal(radio=1)
-    coord = CoordenadaHexagonal(0, 0)
+    carta = BaseCard({'id': 1, 'nombre': 'Test', 'stats': {'vida': 5, 'dano_fisico': 1}})
+    tablero = HexBoard(radio=1)
+    coord = HexCoordinate(0, 0)
     tablero.colocar_carta(coord, carta)
     assert tablero.obtener_carta_en(coord) is carta
     carta.recibir_dano(10)

--- a/tests/test_hex_utils.py
+++ b/tests/test_hex_utils.py
@@ -5,11 +5,11 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.utils.hex_utils import pixel_to_hex, hex_to_pixel
-from src.game.tablero.coordenada import CoordenadaHexagonal
+from src.game.board.hex_coordinate import HexCoordinate
 
 @pytest.mark.parametrize("size,offset", [(10,(0,0)), (20,(5,5)), (30,(10,15))])
 def test_round_trip(size, offset):
-    coords = [CoordenadaHexagonal(q,r) for q in range(-3,4) for r in range(-3,4) if -q - r >= -3 and -q - r <=3]
+    coords = [HexCoordinate(q,r) for q in range(-3,4) for r in range(-3,4) if -q - r >= -3 and -q - r <=3]
     for c in coords:
         x, y = hex_to_pixel(c, size, offset)
         assert pixel_to_hex(x, y, size, offset) == c


### PR DESCRIPTION
## Summary
- rename core card modules to English names
- update board module names and class names
- adjust imports in the project
- update tests for new names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538701e6f48326be89468bf0263739