### PR TITLE
Implement JSON-based behavior system

### DIFF
--- a/docs/behavior_json_format.md
+++ b/docs/behavior_json_format.md
@@ -1,0 +1,32 @@
+# Formato de configuracion de comportamientos
+
+Los comportamientos de movimiento y combate se definen en
+`src/game/comportamientos/behaviors_config.json`.
+Cada grupo (`movements` o `combats`) contiene un diccionario donde la clave es el
+nombre del comportamiento y el valor una lista de **steps**.
+
+Un step puede tener los campos:
+- `condition`: nombre de una condicion basica definida en
+  `behavior_primitives.CONDITIONS`.
+- `action`: nombre de una accion basica definida en
+  `behavior_primitives.ACTIONS`.
+
+Las condiciones se evaluan antes de ejecutar la accion. Todas las acciones
+reciben `(carta, tablero, info_entorno)` y pueden devolver interacciones.
+
+Ejemplo simplificado:
+```json
+{
+  "movements": {
+    "explorador": {"steps": [{"action": "mover_aleatorio"}]}
+  },
+  "combats": {
+    "agresivo": {
+      "steps": [
+        {"condition": "enemigo_en_rango", "action": "atacar_objetivo"},
+        {"condition": "enemigo_visible", "action": "mover_hacia_enemigo"}
+      ]
+    }
+  }
+}
+```

--- a/src/game/comportamientos/__init__.py
+++ b/src/game/comportamientos/__init__.py
@@ -1,17 +1,5 @@
-"""Comportamientos package reorganized."""
+"""Módulo de comportamientos."""
 
 from .core.behavior_manager import BehaviorManager
-from .legacy.OLD.behavior_executor import BehaviorExecutor
-from .legacy.OLD.movement_behaviors import MovementBehavior, MovementProcessor
-from .legacy.OLD.combat_behaviors import CombatBehavior, CombatProcessor
-from .legacy.OLD.behavior_restrictions import BehaviorRestrictions
 
-__all__ = [
-    "BehaviorManager",
-    "BehaviorExecutor",
-    "MovementBehavior",
-    "MovementProcessor",
-    "CombatBehavior",
-    "CombatProcessor",
-    "BehaviorRestrictions",
-]
+__all__ = ["BehaviorManager"]

--- a/src/game/comportamientos/behavior_adapter.py
+++ b/src/game/comportamientos/behavior_adapter.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import List, Any
+
+from .behavior_engine import BehaviorEngine
+
+# Map legacy names to new ones
+LEGACY_MOVEMENT_MAP = {
+    "explorador": "explorador",
+    "merodeador": "explorador",
+    "seguidor": "explorador",
+    "huir": "huir",
+    "regreso": "parado",
+    "parado": "parado",
+    "cazador": "explorador",
+}
+
+LEGACY_COMBAT_MAP = {
+    "agresivo": "agresivo",
+    "defensivo": "defensivo",
+    "guardian": "defensivo",
+    "ignorar": "ignorar",
+}
+
+_engine = BehaviorEngine()
+
+
+class BehaviorExecutor:
+    """Compatibility adapter that mirrors the old interface."""
+
+    def ejecutar(self, carta, tablero) -> List[Any]:
+        mov = LEGACY_MOVEMENT_MAP.get(getattr(carta, "movement_behavior", "parado"), "parado")
+        com = LEGACY_COMBAT_MAP.get(getattr(carta, "combat_behavior", "ignorar"), "ignorar")
+        carta.movement_behavior = mov
+        carta.combat_behavior = com
+        return _engine.execute(carta, tablero)

--- a/src/game/comportamientos/behavior_engine.py
+++ b/src/game/comportamientos/behavior_engine.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+from typing import Dict, Any, List
+
+from .behavior_primitives import ACTIONS, CONDITIONS
+from src.game.combate.ia.ia_utilidades import obtener_info_entorno
+
+
+class BehaviorEngine:
+    """Generic behavior executor driven by JSON configuration."""
+
+    def __init__(self, config_path: str | None = None):
+        if config_path is None:
+            config_path = Path(__file__).with_name("behaviors_config.json")
+        with open(config_path, "r", encoding="utf-8") as f:
+            self.config: Dict[str, Any] = json.load(f)
+
+    def execute(self, carta, tablero) -> List[Any]:
+        info = obtener_info_entorno(carta, tablero)
+        movimientos = self.config.get("movements", {})
+        combates = self.config.get("combats", {})
+
+        mov = movimientos.get(getattr(carta, "movement_behavior", "parado"), {})
+        self._run_steps(mov.get("steps", []), carta, tablero, info)
+
+        com = combates.get(getattr(carta, "combat_behavior", "ignorar"), {})
+        return self._run_steps(com.get("steps", []), carta, tablero, info)
+
+    def _run_steps(self, steps: List[Dict[str, Any]], carta, tablero, info) -> List[Any]:
+        resultado: List[Any] = []
+        for paso in steps:
+            cond_name = paso.get("condition")
+            if cond_name:
+                cond = CONDITIONS.get(cond_name)
+                if cond is None or not cond(carta, tablero, info):
+                    continue
+            action = ACTIONS.get(paso.get("action"))
+            if action:
+                res = action(carta, tablero, info)
+                if res:
+                    resultado.extend(res)
+        return resultado

--- a/src/game/comportamientos/behavior_primitives.py
+++ b/src/game/comportamientos/behavior_primitives.py
@@ -1,0 +1,86 @@
+import random
+from typing import Callable, Dict
+# Las utilidades se importan de forma perezosa para evitar ciclos
+
+
+# Conditions return bool
+
+def condicion_enemigo_en_rango(carta, tablero, info_entorno):
+    return bool(info_entorno.get("enemigos_en_rango"))
+
+
+def condicion_enemigo_visible(carta, tablero, info_entorno):
+    return bool(info_entorno.get("enemigos", info_entorno.get("enemigos_en_rango", [])))
+
+
+def condicion_ha_recibido_dano(carta, tablero, info_entorno):
+    return carta.stats_combate.get("dano_recibido", 0) > 0
+
+
+# Actions return list of Interaccion or None
+
+def accion_mover_aleatorio(carta, tablero, info_entorno):
+    libres = tablero.coordenadas_libres()
+    if not libres or carta.coordenada is None:
+        return []
+    destino = random.choice(libres)
+    from src.game.combate.ia.ia_utilidades import mover_carta_con_pathfinding
+    mover_carta_con_pathfinding(carta, destino, tablero)
+    return []
+
+
+def accion_mover_hacia_enemigo(carta, tablero, info_entorno):
+    enemigos = info_entorno.get("enemigos_en_rango") or info_entorno.get("enemigos", [])
+    if not enemigos:
+        return []
+    objetivo = enemigos[0]
+    from src.game.combate.ia.ia_utilidades import mover_carta_con_pathfinding
+    mover_carta_con_pathfinding(carta, objetivo.coordenada, tablero)
+    return []
+
+
+def accion_mover_lejos(carta, tablero, info_entorno):
+    enemigos = info_entorno.get("enemigos_en_rango")
+    if not enemigos or carta.coordenada is None:
+        return []
+    origen = carta.coordenada
+    opciones = [c for c in origen.vecinos() if tablero.esta_dentro_del_tablero(c) and tablero.esta_vacia(c)]
+    opciones.sort(key=lambda c: c.distancia(enemigos[0].coordenada), reverse=True)
+    if opciones:
+        from src.game.combate.ia.ia_utilidades import mover_carta_con_pathfinding
+        mover_carta_con_pathfinding(carta, opciones[0], tablero)
+    return []
+
+
+def accion_atacar_objetivo(carta, tablero, info_entorno):
+    from src.game.combate.interacciones.interaccion_modelo import Interaccion, TipoInteraccion
+    from src.game.combate.ia.ia_utilidades import atacar_si_en_rango
+
+    enemigos = info_entorno.get("enemigos_en_rango")
+    if not enemigos:
+        return []
+    objetivo = enemigos[0]
+    if atacar_si_en_rango(carta, objetivo):
+        return [
+            Interaccion(
+                fuente_id=carta.id,
+                objetivo_id=objetivo.id,
+                tipo=TipoInteraccion.ATAQUE,
+                metadata={"dano_base": carta.dano_fisico_actual},
+            )
+        ]
+    return []
+
+
+CONDITIONS: Dict[str, Callable] = {
+    "enemigo_en_rango": condicion_enemigo_en_rango,
+    "enemigo_visible": condicion_enemigo_visible,
+    "ha_recibido_dano": condicion_ha_recibido_dano,
+}
+
+ACTIONS: Dict[str, Callable] = {
+    "mover_aleatorio": accion_mover_aleatorio,
+    "mover_hacia_enemigo": accion_mover_hacia_enemigo,
+    "mover_lejos": accion_mover_lejos,
+    "atacar_objetivo": accion_atacar_objetivo,
+}

--- a/src/game/comportamientos/behavior_validator.py
+++ b/src/game/comportamientos/behavior_validator.py
@@ -1,0 +1,24 @@
+from typing import Dict, Any
+from .behavior_primitives import ACTIONS, CONDITIONS
+
+
+class BehaviorValidator:
+    """Validates behavior configuration."""
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+
+    def validate(self) -> bool:
+        for group in ("movements", "combats"):
+            behaviors = self.config.get(group, {})
+            for name, data in behaviors.items():
+                if not isinstance(data, dict):
+                    raise ValueError(f"Behavior {name} debe ser un objeto")
+                for step in data.get("steps", []):
+                    cond = step.get("condition")
+                    if cond and cond not in CONDITIONS:
+                        raise ValueError(f"Condicion desconocida: {cond}")
+                    action = step.get("action")
+                    if action not in ACTIONS:
+                        raise ValueError(f"Accion desconocida: {action}")
+        return True

--- a/src/game/comportamientos/behaviors_config.json
+++ b/src/game/comportamientos/behaviors_config.json
@@ -1,0 +1,33 @@
+{
+  "movements": {
+    "parado": {
+      "steps": []
+    },
+    "explorador": {
+      "steps": [
+        {"action": "mover_aleatorio"}
+      ]
+    },
+    "huir": {
+      "steps": [
+        {"condition": "enemigo_en_rango", "action": "mover_lejos"}
+      ]
+    }
+  },
+  "combats": {
+    "ignorar": {
+      "steps": []
+    },
+    "agresivo": {
+      "steps": [
+        {"condition": "enemigo_en_rango", "action": "atacar_objetivo"},
+        {"condition": "enemigo_visible", "action": "mover_hacia_enemigo"}
+      ]
+    },
+    "defensivo": {
+      "steps": [
+        {"condition": "ha_recibido_dano", "action": "atacar_objetivo"}
+      ]
+    }
+  }
+}

--- a/src/game/comportamientos/legacy/OLD/behavior_executor.py
+++ b/src/game/comportamientos/legacy/OLD/behavior_executor.py
@@ -1,37 +1,18 @@
+"""Compatibilidad: redirige a BehaviorExecutor basado en JSON."""
 from __future__ import annotations
 
-from typing import List
+from typing import List, Any
 
-from src.game.combate.ia.ia_utilidades import obtener_info_entorno
-from src.game.combate.interacciones.interaccion_modelo import Interaccion
-from .movement_behaviors import MovementBehavior, MovementProcessor
-from .combat_behaviors import CombatBehavior, CombatProcessor
+from ...behavior_adapter import BehaviorExecutor as _Adapter
+
+_executor = _Adapter()
 
 
 class BehaviorExecutor:
-    """Coordinador de comportamientos de movimiento y combate."""
+    """Mantiene la interfaz original para código legacy."""
 
     def __init__(self):
-        self._cache_mov = {}
-        self._cache_com = {}
+        self._engine = _executor
 
-    def _get_movement_processor(self, movimiento: MovementBehavior) -> MovementProcessor:
-        if movimiento not in self._cache_mov:
-            self._cache_mov[movimiento] = MovementProcessor(movimiento)
-        return self._cache_mov[movimiento]
-
-    def _get_combat_processor(self, combate: CombatBehavior) -> CombatProcessor:
-        if combate not in self._cache_com:
-            self._cache_com[combate] = CombatProcessor(combate)
-        return self._cache_com[combate]
-
-    def ejecutar(self, carta, tablero) -> List[Interaccion]:
-        info_entorno = obtener_info_entorno(carta, tablero)
-        mov_tipo = getattr(carta, "movement_behavior", MovementBehavior.PARADO)
-        com_tipo = getattr(carta, "combat_behavior", CombatBehavior.IGNORAR)
-        mov_proc = self._get_movement_processor(MovementBehavior(mov_tipo))
-        com_proc = self._get_combat_processor(CombatBehavior(com_tipo))
-
-        mov_proc.ejecutar(carta, tablero, info_entorno)
-        interacciones = com_proc.ejecutar(carta, tablero, info_entorno)
-        return interacciones
+    def ejecutar(self, carta, tablero) -> List[Any]:
+        return self._engine.ejecutar(carta, tablero)


### PR DESCRIPTION
## Summary
- add generic `BehaviorEngine` driven by JSON config
- define basic primitives and config validator
- provide `BehaviorExecutor` adapter for legacy compatibility
- redirect old executor to the new engine
- document JSON behavior format

## Testing
- `pytest -q`
- manual validation of behavior config

------
https://chatgpt.com/codex/tasks/task_e_6853b4a8d3fc8326afbaac3a09e4d962