### PR TITLE
Implement custom vision patterns

### DIFF
--- a/src/data/cartas/personajes_historicos.json
+++ b/src/data/cartas/personajes_historicos.json
@@ -15,8 +15,7 @@
       "rango_movimiento": 2,
       "rango_ataque": 3,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -34,7 +33,37 @@
         "trigger": "al_recibir_dano"
       }
     ],
-    "descripcion": "Físico y matemático inglés, padre de la mecánica clásica"
+    "descripcion": "Físico y matemático inglés, padre de la mecánica clásica",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 2,
@@ -52,8 +81,7 @@
       "rango_movimiento": 3,
       "rango_ataque": 2,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -71,7 +99,37 @@
         "trigger": "permanente"
       }
     ],
-    "descripcion": "Genio renacentista: artista, inventor, científico e ingeniero"
+    "descripcion": "Genio renacentista: artista, inventor, científico e ingeniero",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 3,
@@ -89,8 +147,7 @@
       "rango_movimiento": 1,
       "rango_ataque": 3,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -110,7 +167,37 @@
         "area": "adyacentes"
       }
     ],
-    "descripcion": "Física y química polaca, pionera en radioactividad"
+    "descripcion": "Física y química polaca, pionera en radioactividad",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 4,
@@ -128,8 +215,7 @@
       "rango_movimiento": 2,
       "rango_ataque": 4,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -149,7 +235,37 @@
         "cantidad": 15
       }
     ],
-    "descripcion": "Inventor serbio-estadounidense, genio de la electricidad"
+    "descripcion": "Inventor serbio-estadounidense, genio de la electricidad",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 5,
@@ -167,8 +283,7 @@
       "rango_movimiento": 2,
       "rango_ataque": 1,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -187,7 +302,37 @@
         "area": "adyacentes"
       }
     ],
-    "descripcion": "Emperador francés y genio militar que conquistó gran parte de Europa"
+    "descripcion": "Emperador francés y genio militar que conquistó gran parte de Europa",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 6,
@@ -205,8 +350,7 @@
       "rango_movimiento": 1,
       "rango_ataque": 1,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -224,7 +368,37 @@
         "trigger": "al_ser_atacado"
       }
     ],
-    "descripcion": "Líder independentista indio, promotor de la no violencia"
+    "descripcion": "Líder independentista indio, promotor de la no violencia",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 7,
@@ -242,8 +416,7 @@
       "rango_movimiento": 2,
       "rango_ataque": 2,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -262,7 +435,37 @@
         "trigger": "enemigo_eliminado_por_aliado"
       }
     ],
-    "descripcion": "Última faraona de Egipto, famosa por su inteligencia y carisma"
+    "descripcion": "Última faraona de Egipto, famosa por su inteligencia y carisma",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 8,
@@ -280,8 +483,7 @@
       "rango_movimiento": 1,
       "rango_ataque": 2,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -299,7 +501,37 @@
         "terreno": "rio"
       }
     ],
-    "descripcion": "Matemático, físico e ingeniero griego de la antigüedad"
+    "descripcion": "Matemático, físico e ingeniero griego de la antigüedad",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 9,
@@ -317,8 +549,7 @@
       "rango_movimiento": 2,
       "rango_ataque": 1,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -338,7 +569,37 @@
         "solo_una_vez": true
       }
     ],
-    "descripcion": "Heroína francesa que liberó Orleans durante la Guerra de los Cien Años"
+    "descripcion": "Heroína francesa que liberó Orleans durante la Guerra de los Cien Años",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 10,
@@ -356,8 +617,7 @@
       "rango_movimiento": 1,
       "rango_ataque": 2,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -377,7 +637,37 @@
         "multiplicador": 1.5
       }
     ],
-    "descripcion": "Filósofo griego, discípulo de Platón y maestro de Alejandro Magno"
+    "descripcion": "Filósofo griego, discípulo de Platón y maestro de Alejandro Magno",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 11,
@@ -395,8 +685,7 @@
       "rango_movimiento": 2,
       "rango_ataque": 3,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -415,7 +704,37 @@
         "area": "adyacentes"
       }
     ],
-    "descripcion": "Astrónomo y físico italiano, pionero del método científico"
+    "descripcion": "Astrónomo y físico italiano, pionero del método científico",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 12,
@@ -433,8 +752,7 @@
       "rango_movimiento": 2,
       "rango_ataque": 3,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -452,7 +770,37 @@
         "trigger": "permanente"
       }
     ],
-    "descripcion": "Considerada la primera programadora de la historia"
+    "descripcion": "Considerada la primera programadora de la historia",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 13,
@@ -470,8 +818,7 @@
       "rango_movimiento": 1,
       "rango_ataque": 2,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -490,7 +837,37 @@
         "trigger": "inicio_ronda"
       }
     ],
-    "descripcion": "Filósofo griego, fundador de la Academia de Atenas"
+    "descripcion": "Filósofo griego, fundador de la Academia de Atenas",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 14,
@@ -508,8 +885,7 @@
       "rango_movimiento": 2,
       "rango_ataque": 2,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -528,7 +904,37 @@
         "trigger": "victoria_combate"
       }
     ],
-    "descripcion": "Autor del arte de la guerra, estratega militar chino"
+    "descripcion": "Autor del arte de la guerra, estratega militar chino",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 15,
@@ -546,8 +952,7 @@
       "rango_movimiento": 3,
       "rango_ataque": 1,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -565,7 +970,37 @@
         "trigger": "enemigo_eliminado"
       }
     ],
-    "descripcion": "Fundador del imperio Mongol, famoso conquistador"
+    "descripcion": "Fundador del imperio Mongol, famoso conquistador",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 16,
@@ -583,8 +1018,7 @@
       "rango_movimiento": 3,
       "rango_ataque": 1,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -603,7 +1037,37 @@
         "area": "cercanos"
       }
     ],
-    "descripcion": "Rey de Macedonia que creó uno de los mayores imperios"
+    "descripcion": "Rey de Macedonia que creó uno de los mayores imperios",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 17,
@@ -621,8 +1085,7 @@
       "rango_movimiento": 2,
       "rango_ataque": 3,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -641,7 +1104,37 @@
         "trigger": "habilidad_usada"
       }
     ],
-    "descripcion": "Físico teórico alemán creador de la relatividad"
+    "descripcion": "Físico teórico alemán creador de la relatividad",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 18,
@@ -659,8 +1152,7 @@
       "rango_movimiento": 1,
       "rango_ataque": 2,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -679,7 +1171,37 @@
         "trigger": "al_recibir_dano"
       }
     ],
-    "descripcion": "Autor de Don Quijote, uno de los grandes escritores españoles"
+    "descripcion": "Autor de Don Quijote, uno de los grandes escritores españoles",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 19,
@@ -697,8 +1219,7 @@
       "rango_movimiento": 3,
       "rango_ataque": 1,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -716,7 +1237,37 @@
         "trigger": "permanente"
       }
     ],
-    "descripcion": "Famoso explorador veneciano y mercader"
+    "descripcion": "Famoso explorador veneciano y mercader",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   },
   {
     "id": 20,
@@ -734,8 +1285,7 @@
       "rango_movimiento": 2,
       "rango_ataque": 2,
       "velocidad_movimiento": 0.5,
-      "velocidad_ataque": 1.5,
-      "rango_vision": 1
+      "velocidad_ataque": 1.5
     },
     "habilidades": [
       {
@@ -754,6 +1304,36 @@
         "trigger": "permanente"
       }
     ],
-    "descripcion": "Científica clave en el descubrimiento de la estructura del ADN"
+    "descripcion": "Científica clave en el descubrimiento de la estructura del ADN",
+    "vision_pattern": [
+      {
+        "q": -1,
+        "r": 0
+      },
+      {
+        "q": -1,
+        "r": 1
+      },
+      {
+        "q": 0,
+        "r": -1
+      },
+      {
+        "q": 0,
+        "r": 0
+      },
+      {
+        "q": 0,
+        "r": 1
+      },
+      {
+        "q": 1,
+        "r": -1
+      },
+      {
+        "q": 1,
+        "r": 0
+      }
+    ]
   }
 ]

--- a/src/game/board/hex_coordinate.py
+++ b/src/game/board/hex_coordinate.py
@@ -13,6 +13,12 @@ class HexCoordinate:
     def __sub__(self, otro: "HexCoordinate") -> "HexCoordinate":
         return HexCoordinate(self.q - otro.q, self.r - otro.r)
 
+    def __mul__(self, escalar: int) -> "HexCoordinate":
+        """Multiplica la coordenada por un escalar"""
+        return HexCoordinate(self.q * escalar, self.r * escalar)
+
+    __rmul__ = __mul__
+
     def s(self) -> int:
         return -self.q - self.r
 
@@ -51,3 +57,57 @@ class HexCoordinate:
 
     def __repr__(self):
         return f"({self.q}, {self.r})"
+
+
+# === Utilidades de patrones de visión ===
+
+# Direcciones axiales básicas, útiles para construir patrones.
+DIRECCIONES = [
+    HexCoordinate(1, 0),
+    HexCoordinate(1, -1),
+    HexCoordinate(0, -1),
+    HexCoordinate(-1, 0),
+    HexCoordinate(-1, 1),
+    HexCoordinate(0, 1),
+]
+
+
+def aplicar_offset(base: "HexCoordinate", offset: "HexCoordinate") -> "HexCoordinate":
+    """Devuelve ``base`` desplazada por ``offset``"""
+    return HexCoordinate(base.q + offset.q, base.r + offset.r)
+
+
+def patron_circular(radio: int) -> List[HexCoordinate]:
+    """Genera un patrón circular centrado en (0,0)"""
+    return HexCoordinate(0, 0).obtener_area(radio)
+
+
+def patron_linea(direccion: HexCoordinate, longitud: int) -> List[HexCoordinate]:
+    """Genera un patrón en línea recta desde el origen"""
+    coords = [HexCoordinate(0, 0)]
+    for i in range(1, longitud + 1):
+        coords.append(direccion * i)
+    return coords
+
+
+def patron_cono(direccion: HexCoordinate, longitud: int) -> List[HexCoordinate]:
+    """Genera un patrón de cono sencillo en la dirección indicada"""
+    coords = [HexCoordinate(0, 0)]
+    idx = DIRECCIONES.index(direccion)
+    izquierda = DIRECCIONES[(idx - 1) % len(DIRECCIONES)]
+    derecha = DIRECCIONES[(idx + 1) % len(DIRECCIONES)]
+    for dist in range(1, longitud + 1):
+        base = direccion * dist
+        coords.append(base)
+        for offset in range(1, dist + 1):
+            coords.append(base + izquierda * offset)
+            coords.append(base + derecha * offset)
+    # Eliminar duplicados preservando orden
+    vistos = set()
+    unicos = []
+    for c in coords:
+        if (c.q, c.r) not in vistos:
+            unicos.append(c)
+            vistos.add((c.q, c.r))
+    return unicos
+

--- a/src/game/cards/base_card.py
+++ b/src/game/cards/base_card.py
@@ -85,7 +85,16 @@ class BaseCard:
         self.rango_ataque_base = stats_data.get('rango_ataque', 1)
         self.velocidad_movimiento = stats_data.get('velocidad_movimiento', 1.0)
         self.velocidad_ataque = stats_data.get('velocidad_ataque', 1.5)
-        self.rango_vision = stats_data.get('rango_vision', 2)
+        self.rango_vision = stats_data.get('rango_vision')
+
+        from src.game.board.hex_coordinate import HexCoordinate, patron_circular
+
+        vision_data = datos_carta.get('vision_pattern')
+        if vision_data:
+            self.vision_pattern = [HexCoordinate(v['q'], v['r']) for v in vision_data]
+        else:
+            radio = self.rango_vision if self.rango_vision is not None else 1
+            self.vision_pattern = patron_circular(radio)
 
         # Control interno de tiempos para acciones
         self.ultimo_ataque = 0.0
@@ -158,6 +167,19 @@ class BaseCard:
             "tier": tier,
             "stats": {"vida": 100, "dano_fisico": 10}
         })
+
+    def calcular_celdas_visibles(self, posicion_actual):
+        """Devuelve las celdas visibles aplicando el patrón de visión"""
+        if posicion_actual is None:
+            return []
+
+        celdas = []
+        for offset in self.vision_pattern:
+            destino = posicion_actual + offset
+            if self.tablero and not self.tablero.esta_dentro_del_tablero(destino):
+                continue
+            celdas.append(destino)
+        return celdas
 
     def _cargar_habilidades(self, habilidades_data: List[Dict[str, Any]]):
         """Carga las habilidades desde los datos JSON"""

--- a/src/game/combate/ia/ia_utilidades.py
+++ b/src/game/combate/ia/ia_utilidades.py
@@ -46,8 +46,7 @@ def calcular_vision_jugador(jugador, mapa_global):
     # Visibilidad desde cartas propias en el mapa global
     for coord, carta in mapa_global.tablero.celdas.items():
         if carta is not None and getattr(carta, "duenio", None) == jugador:
-            area = coord.obtener_area(carta.rango_vision)
-            celdas_visibles.update(area)
+            celdas_visibles.update(carta.calcular_celdas_visibles(coord))
 
     return celdas_visibles
 

--- a/src/interfaces/gui/widgets/hex_canvas.py
+++ b/src/interfaces/gui/widgets/hex_canvas.py
@@ -94,7 +94,7 @@ class InterfazMapaGlobal(ttk.Frame):
 
         for coord, carta in self.mapa.tablero.celdas.items():
             if carta is not None and getattr(carta, "duenio", None) == jugador_actual:
-                visibles.update(coord.obtener_area(carta.rango_vision))
+                visibles.update(carta.calcular_celdas_visibles(coord))
 
         return visibles
 

--- a/tests/test_vision_pattern.py
+++ b/tests/test_vision_pattern.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.game.board.hex_board import HexBoard
+from src.game.board.hex_coordinate import HexCoordinate, patron_circular
+from src.game.cards.base_card import BaseCard
+
+
+def test_celdas_visibles_por_patron():
+    card = BaseCard({'id': 1, 'vision_pattern': [{'q':1,'r':0}, {'q':2,'r':0}]})
+    board = HexBoard(radio=3)
+    coord = HexCoordinate(0,0)
+    board.colocar_carta(coord, card)
+    visibles = card.calcular_celdas_visibles(coord)
+    assert HexCoordinate(1,0) in visibles
+    assert HexCoordinate(2,0) in visibles
+
+
+def test_fallback_patron_circular():
+    card = BaseCard({'id': 2, 'stats': {'rango_vision': 1}})
+    board = HexBoard(radio=2)
+    coord = HexCoordinate(0,0)
+    board.colocar_carta(coord, card)
+    expected = patron_circular(1)
+    assert set(card.calcular_celdas_visibles(coord)) == set([coord + o for o in expected])
+


### PR DESCRIPTION
## Summary
- support multiplying HexCoordinate and add helper patterns
- load `vision_pattern` in BaseCard
- compute visible cells using card pattern
- adapt IA utilities and GUI to use patterns
- convert historical cards JSON to `vision_pattern`
- add tests for new vision logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b96f7b008326b4a59bb3936fab88