### PR TITLE
Expand FastAPI API with board management and websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,12 @@ Tras la última reorganización se eliminaron módulos de compatibilidad que sol
 
 ## API para integraci\u00f3n con Godot
 
-Se incluye un servidor basado en **FastAPI** en `godot_integration/api/server.py`. Por defecto expone dos endpoints:
+Se incluye un servidor basado en **FastAPI** en `godot_integration/api/server.py`. Los principales endpoints son:
 
 - `/status` retorna un estado simple.
-- `/board` devuelve el estado actual del tablero en formato JSON.
+- `/board` devuelve el estado actual del tablero.
+- `/board/place` coloca una carta en una coordenada.
+- `/board/move` mueve una carta entre coordenadas.
+- `/board/remove` elimina la carta en una coordenada.
 
-Esto facilita que un cliente en Godot pueda consultar el estado del juego o mostrar el tablero.
+Adicionalmente se expone un WebSocket en `/ws` que notifica cambios en el tablero en tiempo real. Esto facilita que un cliente en Godot pueda consultar el estado del juego y recibir actualizaciones inmediatas.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,13 @@
+# API Reference
+
+The FastAPI server in `godot_integration/api/server.py` exposes the following endpoints:
+
+- `GET /status` – basic health check.
+- `GET /board` – returns board state with statistics.
+- `POST /board/place` – place a card on the board.
+- `POST /board/move` – move a card between coordinates.
+- `POST /board/remove` – remove a card from a coordinate.
+- `WebSocket /ws` – receive real time board updates.
+
+Each coordinate is represented with `q` and `r` fields. Card creation accepts a `nombre` and optional `id` and `stats` dictionary.
+

--- a/godot_integration/api/server.py
+++ b/godot_integration/api/server.py
@@ -1,18 +1,107 @@
-from fastapi import FastAPI
+from typing import List, Set
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, BackgroundTasks
+from pydantic import BaseModel
+
 from src.game.board.hex_board import HexBoard
+from src.game.board.hex_coordinate import HexCoordinate
+from src.game.cards.base_card import BaseCard
 
 app = FastAPI(title="AutoBattler API")
 
 board = HexBoard(radio=2)
 
+
+class Coordinate(BaseModel):
+    q: int
+    r: int
+
+
+class CardPayload(BaseModel):
+    nombre: str = "Carta"
+    id: int | None = None
+    stats: dict = {}
+
+
+clients: Set[WebSocket] = set()
+
+
+def serialize_board() -> List[dict]:
+    return [
+        {"q": coord.q, "r": coord.r, "card": getattr(card, "nombre", None)}
+        for coord, card in board.obtener_cartas_con_posiciones()
+    ]
+
+
+async def notify_board():
+    payload = {
+        "cartas": serialize_board(),
+        "stats": board.obtener_estadisticas(),
+    }
+    for ws in list(clients):
+        try:
+            await ws.send_json(payload)
+        except WebSocketDisconnect:
+            clients.discard(ws)
+
+
 @app.get("/status")
 def get_status():
     return {"status": "ok"}
 
+
 @app.get("/board")
 def get_board():
-    data = [
-        {"q": coord.q, "r": coord.r, "card": getattr(card, "nombre", None)}
-        for coord, card in board.obtener_cartas_con_posiciones()
-    ]
-    return {"cartas": data, "stats": board.obtener_estadisticas()}
+    return {"cartas": serialize_board(), "stats": board.obtener_estadisticas()}
+
+
+@app.post("/board/place")
+async def place_card(
+    payload: CardPayload, coord: Coordinate, background_tasks: BackgroundTasks
+):
+    card = BaseCard(
+        {
+            "id": payload.id or 0,
+            "nombre": payload.nombre,
+            "stats": payload.stats,
+        }
+    )
+    board.colocar_carta(HexCoordinate(coord.q, coord.r), card)
+    background_tasks.add_task(notify_board)
+    return {"status": "placed"}
+
+
+@app.post("/board/move")
+async def move_card(
+    origin: Coordinate, dest: Coordinate, background_tasks: BackgroundTasks
+):
+    board.mover_carta(
+        HexCoordinate(origin.q, origin.r),
+        HexCoordinate(dest.q, dest.r),
+    )
+    background_tasks.add_task(notify_board)
+    return {"status": "moved"}
+
+
+@app.post("/board/remove")
+async def remove_card(coord: Coordinate, background_tasks: BackgroundTasks):
+    board.quitar_carta(HexCoordinate(coord.q, coord.r))
+    background_tasks.add_task(notify_board)
+    return {"status": "removed"}
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    clients.add(ws)
+    try:
+        await ws.send_json(
+            {
+                "cartas": serialize_board(),
+                "stats": board.obtener_estadisticas(),
+            }
+        )
+        while True:
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        clients.discard(ws)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+
+from godot_integration.api.server import app, board
+from src.game.board.hex_coordinate import HexCoordinate
+
+client = TestClient(app)
+
+
+def test_status_endpoint():
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_place_and_move_card():
+    board.limpiar_tablero()
+    payload = {
+        "nombre": "Test",
+        "id": 1,
+        "stats": {"vida": 5},
+    }
+    resp = client.post(
+        "/board/place",
+        json={"payload": payload, "coord": {"q": 0, "r": 0}},
+    )
+    assert resp.status_code == 200
+    assert board.obtener_carta_en(HexCoordinate(0, 0)) is not None
+
+    resp = client.post(
+        "/board/move",
+        json={
+            "origin": {"q": 0, "r": 0},
+            "dest": {"q": 1, "r": 0},
+        },
+    )
+    assert resp.status_code == 200
+    assert board.obtener_carta_en(HexCoordinate(1, 0)) is not None


### PR DESCRIPTION
## Summary
- enhance README with new endpoints
- document API endpoints in docs/api_reference.md
- implement FastAPI coordinate & card schemas and websocket broadcast
- add integration tests for new endpoints

## Testing
- `black godot_integration/api/server.py`
- `flake8 godot_integration/api/server.py tests/test_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685505479e9883268ce9c495922c6eee