### PR TITLE
Fix pathfinding delay

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.110.0
 uvicorn==0.27.0
+httpx<0.27

--- a/src/game/combate/ia/ia_utilidades.py
+++ b/src/game/combate/ia/ia_utilidades.py
@@ -155,7 +155,10 @@ def mover_carta_con_pathfinding(
         # Anteriormente el primer paso se ejecutaba sin demora, lo que hacía
         # que en comportamientos automáticos la velocidad configurada no se
         # respetara visualmente.
-        evt_id = motor.programar_evento(_ejecutar, delay if indice > 0 else 0.0)
+        # El primer paso también debe respetar el delay configurado
+        # para evitar que la carta se "teletransporte" inmediatamente
+        # al comenzar un movimiento.
+        evt_id = motor.programar_evento(_ejecutar, delay)
         try:
             carta.registrar_evento_activo("movimiento", evt_id)
         except AttributeError:


### PR DESCRIPTION
## Summary
- honor movement speed for first step
- pin httpx runtime dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68550be6c38c8326af8a865e1b6e4a5b