### PR TITLE
Add basic passive ability triggers

### DIFF
--- a/src/game/cards/ability_engine.py
+++ b/src/game/cards/ability_engine.py
@@ -1,5 +1,5 @@
 class AbilityEngine:
-    """Motor simple para ejecutar habilidades definidas en JSON."""
+    """Motor simple para ejecutar habilidades definidas en JSON y gestionar triggers."""
 
     def ejecutar_habilidad(self, caster, habilidad, objetivo=None):
         """Ejecuta los efectos de una habilidad."""
@@ -8,14 +8,27 @@ class AbilityEngine:
             if tipo == "dano" and objetivo is not None:
                 cantidad = efecto.get("cantidad", 0)
                 objetivo.recibir_dano(cantidad, efecto.get("dano_tipo", "fisico"))
-            elif tipo == "curacion" and objetivo is not None:
+            elif tipo == "curacion":
                 cantidad = efecto.get("cantidad", 0)
-                objetivo.curar(cantidad)
+                (objetivo or caster).curar(cantidad)
+            elif tipo == "mana":
+                cantidad = efecto.get("cantidad", 0)
+                (objetivo or caster).ganar_mana(cantidad)
             elif tipo == "buff":
                 stat = efecto.get("stat")
                 valor = efecto.get("valor", 0)
-                (objetivo or caster).aplicar_modificador_stat(stat, valor, False)
+                permanente = efecto.get("permanente", False)
+                (objetivo or caster).aplicar_modificador_stat(stat, valor, permanente)
             # Se pueden agregar más tipos de efecto en el futuro
+
+    def procesar_trigger(self, caster, trigger: str, **kwargs):
+        """Ejecuta habilidades pasivas del caster que coincidan con el trigger."""
+        objetivo = kwargs.get("objetivo")
+        for habilidad in getattr(caster, "habilidades", []):
+            if habilidad.tipo != "pasiva":
+                continue
+            if habilidad.trigger == trigger:
+                self.ejecutar_habilidad(caster, habilidad, objetivo)
 
 
 ability_engine = AbilityEngine()

--- a/src/game/cards/base_card.py
+++ b/src/game/cards/base_card.py
@@ -263,6 +263,11 @@ class BaseCard:
         for hab_data in habilidades_data:
             habilidad = Ability(hab_data)
             self.habilidades.append(habilidad)
+            if habilidad.tipo == "pasiva" and habilidad.trigger == "permanente":
+                try:
+                    ability_engine.ejecutar_habilidad(self, habilidad)
+                except Exception:
+                    pass
 
     # === MÉTODOS DE VIDA Y ESTADO ===
 
@@ -290,6 +295,11 @@ class BaseCard:
         dano_aplicado = min(dano_reducido, self.vida_actual)
         self.vida_actual -= dano_aplicado
 
+        try:
+            ability_engine.procesar_trigger(self, "al_recibir_dano")
+        except Exception:
+            pass
+
         # Verificar muerte
         if self.vida_actual <= 0:
             self.vida_actual = 0
@@ -308,6 +318,11 @@ class BaseCard:
             try:
                 from src.utils.eventos import disparar
                 disparar("carta_muerta", carta=self)
+            except Exception:
+                pass
+
+            try:
+                ability_engine.procesar_trigger(self, "al_morir")
             except Exception:
                 pass
 
@@ -490,6 +505,12 @@ class BaseCard:
         # Reducir cooldowns y reiniciar habilidades por turno
         for habilidad in self.habilidades:
             habilidad.nuevo_turno()
+
+        # Triggers pasivos de inicio de turno
+        try:
+            ability_engine.procesar_trigger(self, "cada_turno")
+        except Exception:
+            pass
 
         # Permitir actuar
         self.puede_actuar = True

--- a/tests/test_ability_system.py
+++ b/tests/test_ability_system.py
@@ -28,3 +28,42 @@ def test_ability_por_turno():
     abil.use(1)
     assert not abil.can_use(1)
     assert abil.can_use(2)
+
+
+def test_pasiva_cada_turno():
+    from src.game.cards.base_card import BaseCard
+    datos = {
+        'id': 1,
+        'stats': {'vida': 10},
+        'habilidades': [
+            {
+                'nombre': 'Regeneracion',
+                'tipo': 'pasiva',
+                'trigger': 'cada_turno',
+                'efectos': [{'tipo': 'curacion', 'cantidad': 2}]
+            }
+        ]
+    }
+    carta = BaseCard(datos)
+    carta.vida_actual = 5
+    carta.iniciar_turno()
+    assert carta.vida_actual == 7
+
+
+def test_pasiva_al_recibir_dano():
+    from src.game.cards.base_card import BaseCard
+    datos = {
+        'id': 2,
+        'stats': {'vida': 10, 'mana_maxima': 20, 'mana_inicial': 0},
+        'habilidades': [
+            {
+                'nombre': 'Concentracion',
+                'tipo': 'pasiva',
+                'trigger': 'al_recibir_dano',
+                'efectos': [{'tipo': 'mana', 'cantidad': 5}]
+            }
+        ]
+    }
+    carta = BaseCard(datos)
+    carta.recibir_dano(3)
+    assert carta.mana_actual == 5


### PR DESCRIPTION
## Summary
- extend ability engine with trigger processing and mana/curacion support
- trigger permanent passives on load and execute triggers on turn start and when damaged or dying
- update tests to cover passive ability triggers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856bf2a83f88326a95a447b9637065f